### PR TITLE
refactor: remove redundant `len` and `nil` check

### DIFF
--- a/internal/base/server/http_funcmap.go
+++ b/internal/base/server/http_funcmap.go
@@ -143,15 +143,13 @@ var funcMap = template.FuncMap{
 func FormatLinkNofollow(html string) string {
 	var hrefRegexp = regexp.MustCompile("(?m)<a.*?[^<]>.*?</a>")
 	match := hrefRegexp.FindAllString(html, -1)
-	if match != nil {
-		for _, v := range match {
-			hasNofollow := strings.Contains(v, "rel=\"nofollow\"")
-			hasSiteUrl := strings.Contains(v, controller.SiteUrl)
-			if !hasSiteUrl {
-				if !hasNofollow {
-					nofollowUrl := strings.Replace(v, "<a", "<a rel=\"nofollow\"", 1)
-					html = strings.Replace(html, v, nofollowUrl, 1)
-				}
+	for _, v := range match {
+		hasNofollow := strings.Contains(v, "rel=\"nofollow\"")
+		hasSiteUrl := strings.Contains(v, controller.SiteUrl)
+		if !hasSiteUrl {
+			if !hasNofollow {
+				nofollowUrl := strings.Replace(v, "<a", "<a rel=\"nofollow\"", 1)
+				html = strings.Replace(html, v, nofollowUrl, 1)
 			}
 		}
 	}

--- a/internal/repo/search_common/search_repo.go
+++ b/internal/repo/search_common/search_repo.go
@@ -146,22 +146,20 @@ func (sr *searchRepo) SearchContents(ctx context.Context, words []string, tagIDs
 	ub.Where(likeConA)
 
 	// check tag
-	if len(tagIDs) > 0 {
-		for ti, tagID := range tagIDs {
-			ast := "tag_rel" + strconv.Itoa(ti)
-			b.Join("INNER", "tag_rel as "+ast, "question.id = "+ast+".object_id").
-				And(builder.Eq{
-					ast + ".tag_id": tagID,
-					ast + ".status": entity.TagRelStatusAvailable,
-				})
-			ub.Join("INNER", "tag_rel as "+ast, "question_id = "+ast+".object_id").
-				And(builder.Eq{
-					ast + ".tag_id": tagID,
-					ast + ".status": entity.TagRelStatusAvailable,
-				})
-			argsQ = append(argsQ, entity.TagRelStatusAvailable, tagID)
-			argsA = append(argsA, entity.TagRelStatusAvailable, tagID)
-		}
+	for ti, tagID := range tagIDs {
+		ast := "tag_rel" + strconv.Itoa(ti)
+		b.Join("INNER", "tag_rel as "+ast, "question.id = "+ast+".object_id").
+			And(builder.Eq{
+				ast + ".tag_id": tagID,
+				ast + ".status": entity.TagRelStatusAvailable,
+			})
+		ub.Join("INNER", "tag_rel as "+ast, "question_id = "+ast+".object_id").
+			And(builder.Eq{
+				ast + ".tag_id": tagID,
+				ast + ".status": entity.TagRelStatusAvailable,
+			})
+		argsQ = append(argsQ, entity.TagRelStatusAvailable, tagID)
+		argsA = append(argsA, entity.TagRelStatusAvailable, tagID)
 	}
 
 	// check user
@@ -265,16 +263,14 @@ func (sr *searchRepo) SearchQuestions(ctx context.Context, words []string, tagID
 	b.Where(likeConQ)
 
 	// check tag
-	if len(tagIDs) > 0 {
-		for ti, tagID := range tagIDs {
-			ast := "tag_rel" + strconv.Itoa(ti)
-			b.Join("INNER", "tag_rel as "+ast, "question.id = "+ast+".object_id").
-				And(builder.Eq{
-					ast + ".tag_id": tagID,
-					ast + ".status": entity.TagRelStatusAvailable,
-				})
-			args = append(args, entity.TagRelStatusAvailable, tagID)
-		}
+	for ti, tagID := range tagIDs {
+		ast := "tag_rel" + strconv.Itoa(ti)
+		b.Join("INNER", "tag_rel as "+ast, "question.id = "+ast+".object_id").
+			And(builder.Eq{
+				ast + ".tag_id": tagID,
+				ast + ".status": entity.TagRelStatusAvailable,
+			})
+		args = append(args, entity.TagRelStatusAvailable, tagID)
 	}
 
 	// check need filter has not accepted
@@ -376,16 +372,14 @@ func (sr *searchRepo) SearchAnswers(ctx context.Context, words []string, tagIDs 
 	b.Where(likeConA)
 
 	// check tag
-	if len(tagIDs) > 0 {
-		for ti, tagID := range tagIDs {
-			ast := "tag_rel" + strconv.Itoa(ti)
-			b.Join("INNER", "tag_rel as "+ast, "question_id = "+ast+".object_id").
-				And(builder.Eq{
-					ast + ".tag_id": tagID,
-					ast + ".status": entity.TagRelStatusAvailable,
-				})
-			args = append(args, entity.TagRelStatusAvailable, tagID)
-		}
+	for ti, tagID := range tagIDs {
+		ast := "tag_rel" + strconv.Itoa(ti)
+		b.Join("INNER", "tag_rel as "+ast, "question_id = "+ast+".object_id").
+			And(builder.Eq{
+				ast + ".tag_id": tagID,
+				ast + ".status": entity.TagRelStatusAvailable,
+			})
+		args = append(args, entity.TagRelStatusAvailable, tagID)
 	}
 
 	// check limit accepted


### PR DESCRIPTION
From the Go specification (https://go.dev/ref/spec#For_range):

> "1. For a nil slice, the number of iterations is 0."

`len` returns 0 if the slice is nil (https://pkg.go.dev/builtin#len). Therefore, checking `len(v) > 0` around a loop is unnecessary.

Example Go playground: https://go.dev/play/p/s3FZcKC8ltm