### PR TITLE
fix issue:userprofile hide unlisted post(#661)

### DIFF
--- a/internal/repo/question/question_repo.go
+++ b/internal/repo/question/question_repo.go
@@ -347,7 +347,7 @@ func (qr *questionRepo) SitemapQuestions(ctx context.Context, page, pageSize int
 }
 
 // GetQuestionPage query question page
-func (qr *questionRepo) GetQuestionPage(ctx context.Context, page, pageSize int, userID, tagID, orderCond string, inDays int) (
+func (qr *questionRepo) GetQuestionPage(ctx context.Context, page, pageSize int, userID, tagID, orderCond string, inDays int, showHidden bool) (
 	questionList []*entity.Question, total int64, err error) {
 	questionList = make([]*entity.Question, 0)
 
@@ -360,6 +360,9 @@ func (qr *questionRepo) GetQuestionPage(ctx context.Context, page, pageSize int,
 	}
 	if len(userID) > 0 {
 		session.And("question.user_id = ?", userID)
+		if !showHidden {
+			session.And("question.show = ?", entity.QuestionShow)
+		}
 	} else {
 		session.And("question.show = ?", entity.QuestionShow)
 	}

--- a/internal/schema/question_schema.go
+++ b/internal/schema/question_schema.go
@@ -353,6 +353,7 @@ type QuestionPageReq struct {
 	LoginUserID      string `json:"-"`
 	UserIDBeSearched string `json:"-"`
 	TagID            string `json:"-"`
+	ShowHidden       bool   `json:"-"`
 }
 
 const (

--- a/internal/service/question_common/question.go
+++ b/internal/service/question_common/question.go
@@ -54,7 +54,7 @@ type QuestionRepo interface {
 	UpdateQuestion(ctx context.Context, question *entity.Question, Cols []string) (err error)
 	GetQuestion(ctx context.Context, id string) (question *entity.Question, exist bool, err error)
 	GetQuestionList(ctx context.Context, question *entity.Question) (questions []*entity.Question, err error)
-	GetQuestionPage(ctx context.Context, page, pageSize int, userID, tagID, orderCond string, inDays int) (
+	GetQuestionPage(ctx context.Context, page, pageSize int, userID, tagID, orderCond string, inDays int, showHidden bool) (
 		questionList []*entity.Question, total int64, err error)
 	UpdateQuestionStatus(ctx context.Context, questionID string, status int) (err error)
 	UpdateQuestionStatusWithOutUpdateTime(ctx context.Context, question *entity.Question) (err error)


### PR DESCRIPTION
This update fixes a display issue with the question list in profiles

Main changes:

Change the query conditions of the "GetQuestionPage" method of "question_repo" and decide whether to obtain hidden posts from the database based on the new parameter "showHidden".

The "showHidden" parameter is created in the "GetQuestionPage" method of "question_service" based on the role of the logged in user.


test:

The new filter functionality has been thoroughly tested to ensure it operates as expected in a variety of situations. Testing included checking the visibility of posts for different user roles.

Looking forward to your feedback and suggestions on this implementation.

Thank you for considering this pull request.