### PR TITLE
feat: support customized privileges required reputation

### DIFF
--- a/i18n/en_US.yaml
+++ b/i18n/en_US.yaml
@@ -83,6 +83,9 @@ backend:
     level_3:
       description:
         other: Level 3 (high reputation required for mature community)
+    level_custom:
+      description:
+        other: Custom Level
     rank_question_add_label:
       other: Ask question
     rank_answer_add_label:

--- a/internal/base/constant/privilege.go
+++ b/internal/base/constant/privilege.go
@@ -24,7 +24,7 @@ import "github.com/apache/incubator-answer/internal/base/reason"
 type Privilege struct {
 	Key   string `json:"key"`
 	Label string `json:"label"`
-	Value int    `json:"value"`
+	Value int    `validate:"gte=1" json:"value"`
 }
 
 const (

--- a/internal/base/reason/privilege.go
+++ b/internal/base/reason/privilege.go
@@ -20,9 +20,10 @@
 package reason
 
 const (
-	PrivilegeLevel1Desc = "privilege.level_1.description"
-	PrivilegeLevel2Desc = "privilege.level_2.description"
-	PrivilegeLevel3Desc = "privilege.level_3.description"
+	PrivilegeLevel1Desc      = "privilege.level_1.description"
+	PrivilegeLevel2Desc      = "privilege.level_2.description"
+	PrivilegeLevel3Desc      = "privilege.level_3.description"
+	PrivilegeLevelCustomDesc = "privilege.level_custom.description"
 
 	RankQuestionAddLabel               = "privilege.rank_question_add_label"
 	RankAnswerAddLabel                 = "privilege.rank_answer_add_label"

--- a/internal/schema/siteinfo_schema.go
+++ b/internal/schema/siteinfo_schema.go
@@ -285,7 +285,7 @@ const (
 	// PrivilegeLevel3 high
 	PrivilegeLevel3 PrivilegeLevel = 3
 	// PrivilegeLevelCustom custom
-	PrivilegeLevelCustom PrivilegeLevel = 3
+	PrivilegeLevelCustom PrivilegeLevel = 99
 )
 
 type PrivilegeLevel int
@@ -313,13 +313,13 @@ type GetPrivilegesConfigResp struct {
 type PrivilegeOption struct {
 	Level      PrivilegeLevel        `json:"level"`
 	LevelDesc  string                `json:"level_desc"`
-	Privileges []*constant.Privilege `json:"privileges"`
+	Privileges []*constant.Privilege `validate:"dive" json:"privileges"`
 }
 
 // UpdatePrivilegesConfigReq update privileges config request
 type UpdatePrivilegesConfigReq struct {
-	Level  PrivilegeLevel   `validate:"required,min=1,max=99" json:"level"`
-	Custom *PrivilegeOption `json:"custom"`
+	Level  PrivilegeLevel   `validate:"required,min=1,max=3" json:"level"`
+	Custom *PrivilegeOption `validate:"required" json:"custom"`
 }
 
 var (

--- a/internal/schema/siteinfo_schema.go
+++ b/internal/schema/siteinfo_schema.go
@@ -313,7 +313,8 @@ type PrivilegeOption struct {
 
 // UpdatePrivilegesConfigReq update privileges config request
 type UpdatePrivilegesConfigReq struct {
-	Level PrivilegeLevel `validate:"required,min=1,max=3" json:"level"`
+	Level  PrivilegeLevel   `validate:"required,min=1,max=3" json:"level"`
+	Custom *PrivilegeOption `json:"custom"`
 }
 
 var (

--- a/internal/schema/siteinfo_schema.go
+++ b/internal/schema/siteinfo_schema.go
@@ -284,12 +284,17 @@ const (
 	PrivilegeLevel2 PrivilegeLevel = 2
 	// PrivilegeLevel3 high
 	PrivilegeLevel3 PrivilegeLevel = 3
+	// PrivilegeLevelCustom custom
+	PrivilegeLevelCustom PrivilegeLevel = 3
 )
 
 type PrivilegeLevel int
 type PrivilegeOptions []*PrivilegeOption
 
 func (p PrivilegeOptions) Choose(level PrivilegeLevel) (option *PrivilegeOption) {
+	if level == 99 {
+		return &PrivilegeOption{}
+	}
 	for _, op := range p {
 		if op.Level == level {
 			return op
@@ -313,7 +318,7 @@ type PrivilegeOption struct {
 
 // UpdatePrivilegesConfigReq update privileges config request
 type UpdatePrivilegesConfigReq struct {
-	Level  PrivilegeLevel   `validate:"required,min=1,max=3" json:"level"`
+	Level  PrivilegeLevel   `validate:"required,min=1,max=99" json:"level"`
 	Custom *PrivilegeOption `json:"custom"`
 }
 

--- a/internal/schema/siteinfo_schema.go
+++ b/internal/schema/siteinfo_schema.go
@@ -318,12 +318,13 @@ type PrivilegeOption struct {
 
 // UpdatePrivilegesConfigReq update privileges config request
 type UpdatePrivilegesConfigReq struct {
-	Level  PrivilegeLevel   `validate:"required,min=1,max=3" json:"level"`
+	Level  PrivilegeLevel   `validate:"required,min=1,max=99" json:"level"`
 	Custom *PrivilegeOption `validate:"required" json:"custom"`
 }
 
 var (
 	DefaultPrivilegeOptions      PrivilegeOptions
+	DefaultCustomPrivilegeOption *PrivilegeOption
 	privilegeOptionsLevelMapping = map[string][]int{
 		constant.RankQuestionAddKey:               {1, 1, 1},
 		constant.RankAnswerAddKey:                 {1, 1, 1},
@@ -373,5 +374,12 @@ func init() {
 				Key:   privilege.Key,
 			})
 		}
+	}
+
+	// set up default custom privilege option
+	DefaultCustomPrivilegeOption = &PrivilegeOption{
+		Level:      PrivilegeLevelCustom,
+		LevelDesc:  reason.PrivilegeLevelCustomDesc,
+		Privileges: DefaultPrivilegeOptions[0].Privileges,
 	}
 }

--- a/internal/service/siteinfo/siteinfo_service.go
+++ b/internal/service/siteinfo/siteinfo_service.go
@@ -311,8 +311,12 @@ func (s *SiteInfoService) GetPrivilegesConfig(ctx context.Context) (resp *schema
 	if err = s.siteInfoCommonService.GetSiteInfoByType(ctx, constant.SiteTypePrivileges, privilege); err != nil {
 		return nil, err
 	}
+	privilegeOptions := schema.DefaultPrivilegeOptions
+	if privilege.Custom != nil {
+		privilegeOptions = append(privilegeOptions, privilege.Custom)
+	}
 	resp = &schema.GetPrivilegesConfigResp{
-		Options:       s.translatePrivilegeOptions(ctx),
+		Options:       s.translatePrivilegeOptions(ctx, privilegeOptions),
 		SelectedLevel: schema.PrivilegeLevel3,
 	}
 	if privilege != nil && privilege.Level > 0 {
@@ -321,9 +325,9 @@ func (s *SiteInfoService) GetPrivilegesConfig(ctx context.Context) (resp *schema
 	return resp, nil
 }
 
-func (s *SiteInfoService) translatePrivilegeOptions(ctx context.Context) (options []*schema.PrivilegeOption) {
+func (s *SiteInfoService) translatePrivilegeOptions(ctx context.Context, privilegeOptions []*schema.PrivilegeOption) (options []*schema.PrivilegeOption) {
 	la := handler.GetLangByCtx(ctx)
-	for _, option := range schema.DefaultPrivilegeOptions {
+	for _, option := range privilegeOptions {
 		op := &schema.PrivilegeOption{
 			Level:     option.Level,
 			LevelDesc: translator.Tr(la, option.LevelDesc),

--- a/internal/service/siteinfo/siteinfo_service.go
+++ b/internal/service/siteinfo/siteinfo_service.go
@@ -314,6 +314,8 @@ func (s *SiteInfoService) GetPrivilegesConfig(ctx context.Context) (resp *schema
 	privilegeOptions := schema.DefaultPrivilegeOptions
 	if privilege.Custom != nil {
 		privilegeOptions = append(privilegeOptions, privilege.Custom)
+	} else {
+		privilegeOptions = append(privilegeOptions, schema.DefaultCustomPrivilegeOption)
 	}
 	resp = &schema.GetPrivilegesConfigResp{
 		Options:       s.translatePrivilegeOptions(ctx, privilegeOptions),

--- a/ui/src/common/constants.ts
+++ b/ui/src/common/constants.ts
@@ -28,6 +28,7 @@ export const DRAFT_QUESTION_STORAGE_KEY = '_a_dq_';
 export const DRAFT_ANSWER_STORAGE_KEY = '_a_da_';
 export const DRAFT_TIMESIGH_STORAGE_KEY = '|_a_t_s_|';
 export const QUESTIONS_ORDER_STORAGE_KEY = '_a_qok_';
+export const ADMIN_PRIVILEGE_CUSTOM_LEVEL = 99;
 
 export const USER_AGENT_NAMES = {
   SegmentFault: 'SegmentFault',

--- a/ui/src/pages/Admin/Privileges/index.tsx
+++ b/ui/src/pages/Admin/Privileges/index.tsx
@@ -50,8 +50,6 @@ const Index: FC = () => {
   const [formData, setFormData] = useState<FormDataType>(initFormData(schema));
 
   const setFormConfig = (state: FormDataType) => {
-    console.log(state);
-    console.log(formData);
     const selectedLevel = Number(state.level.value);
     const levelOptions = privilege?.options;
     const curLevel = levelOptions?.find((li) => {
@@ -82,6 +80,16 @@ const Index: FC = () => {
       uiState[li.key] = {
         'ui:options': {
           readOnly: curLevel.level !== ADMIN_PRIVILEGE_CUSTOM_LEVEL,
+          validator: (value: string) => {
+            const val = Number(value);
+            if (Number.isNaN(val)) {
+              return 'the input should be number';
+            }
+            if (val < 1) {
+              return 'number should be equal or larger than 1';
+            }
+            return true;
+          },
         },
       };
     });
@@ -135,8 +143,14 @@ const Index: FC = () => {
           msg: t('update', { keyPrefix: 'toast' }),
           variant: 'success',
         });
+        if (reqParams.level === ADMIN_PRIVILEGE_CUSTOM_LEVEL) {
+          getPrivilegeSetting().then((resp) => {
+            setPrivilege(resp);
+          });
+        }
       })
       .catch((err) => {
+        debugger;
         if (err.isError) {
           const data = handleFormError(err, formData);
           setFormData({ ...data });
@@ -148,7 +162,6 @@ const Index: FC = () => {
     if (!privilege) {
       return;
     }
-    debugger;
     setFormConfig({
       level: {
         value: privilege.selected_level,
@@ -163,7 +176,6 @@ const Index: FC = () => {
     });
   }, []);
   const handleOnChange = (state) => {
-    debugger;
     // if updated values in Custom form
     if (
       state.level.value === ADMIN_PRIVILEGE_CUSTOM_LEVEL &&

--- a/ui/src/services/admin/settings.ts
+++ b/ui/src/services/admin/settings.ts
@@ -47,6 +47,11 @@ export interface AdminSettingsPrivilege {
   options: PrivilegeLevel[];
 }
 
+export interface AdminSettingsPrivilegeReq {
+  level: number;
+  custom?: PrivilegeLevel;
+}
+
 export const useGeneralSetting = () => {
   const apiUrl = `/answer/admin/api/siteinfo/general`;
   const { data, error } = useSWR<Type.AdminSettingsGeneral, Error>(
@@ -185,8 +190,6 @@ export const getPrivilegeSetting = () => {
   );
 };
 
-export const putPrivilegeSetting = (level: number) => {
-  return request.put('/answer/admin/api/setting/privileges', {
-    level,
-  });
+export const putPrivilegeSetting = (params: AdminSettingsPrivilegeReq) => {
+  return request.put('/answer/admin/api/setting/privileges', params);
 };


### PR DESCRIPTION
fix #695 .

what this PR did.

- added a custom privilege level in Admin setting.
- added default custom privilege when there's no corresponding settings, which makes it compatible when upgrading from ealier version.
- limited the numbers which should be equal or larger than 1 in both frontend and backend.