### PR TITLE
fix: the answer's content in edit answer page disappears

### DIFF
--- a/ui/src/pages/Questions/EditAnswer/index.tsx
+++ b/ui/src/pages/Questions/EditAnswer/index.tsx
@@ -73,7 +73,7 @@ const Index = () => {
   const [contentChanged, setContentChanged] = useState(false);
   const editCaptcha = useCaptchaModal('edit');
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (data?.info?.content) {
       setFormData({
         ...formData,


### PR DESCRIPTION
fix #713 .

After changing to `useEffect`, the issue was resolved. I don't know why we use `useLayoutEffect`. Pls let me know if something I missed.