### PR TITLE
fix: resolve MeiliSearch plugin not updating new answers

### DIFF
--- a/internal/repo/answer/answer_repo.go
+++ b/internal/repo/answer/answer_repo.go
@@ -416,7 +416,7 @@ func (ar *answerRepo) updateSearch(ctx context.Context, answerID string) (err er
 
 	// get question
 	var (
-		question *entity.Question
+		question = new(entity.Question)
 	)
 	exist, err = ar.data.DB.Context(ctx).Where("id = ?", answer.QuestionID).Get(&question)
 	if err != nil {


### PR DESCRIPTION
Resolve issue with MeiliSearch plugin not updating new answers

Fixes bug reported in Issue #738

Description:
Addressed the issue where new answers were not updating in MeiliSearch when using the MeiliSearch plugin (also probabely for other search plugins). The problem was traced back to a pointer-related error in answer_repo.go (line 417). During debugging, an error message "a pointer to a pointer is not allowed" was encountered.

Debugging Information:
While investigating, I identified a potential problem with the initialization of the question instance. To mitigate the issue, I modified the initialization process.



##738 #bugfix 