### PR TITLE
fix: update answer count when update status

### DIFF
--- a/internal/repo/answer/answer_repo.go
+++ b/internal/repo/answer/answer_repo.go
@@ -183,7 +183,7 @@ func (ar *answerRepo) GetAnswer(ctx context.Context, id string) (
 	return
 }
 
-// GetQuestionCount
+// GetAnswerCount count answer
 func (ar *answerRepo) GetAnswerCount(ctx context.Context) (count int64, err error) {
 	var resp = new(entity.Answer)
 	count, err = ar.data.DB.Context(ctx).Where("status = ?", entity.AnswerStatusAvailable).Count(resp)


### PR DESCRIPTION
When admin delete or recover an answer, answerCount and userAnswerCount did not update.