### PR TITLE
fix: can't search username with '-' character

### DIFF
--- a/internal/schema/search_schema.go
+++ b/internal/schema/search_schema.go
@@ -41,10 +41,32 @@ type SearchDTO struct {
 func (s *SearchDTO) Check() (errField []*validator.FormErrorField, err error) {
 	// Replace special characters.
 	// Special characters will cause the search abnormal, such as search for "#" will get nearly all the content that Markdown format.
-	s.Query = regexp.MustCompile(`[+#.<>_()*]`).ReplaceAllString(s.Query, " ")
-	s.Query = regexp.MustCompile(`\s+`).ReplaceAllString(s.Query, " ")
-	s.Query = strings.TrimSpace(s.Query)
+	replacedContent, patterns := ReplaceSearchContent(s.Query)
+	s.Query = strings.Join(append(patterns, replacedContent), " ")
+
 	return nil, nil
+}
+
+func ReplaceSearchContent(content string) (string, []string) {
+	// Define the regular expressions for key:value pairs and [tag]
+	keyValueRegex := regexp.MustCompile(`\w+:\S+`)
+	tagRegex := regexp.MustCompile(`\[\w+\]`)
+	// Define the pattern for characters to replace
+	replaceCharsPattern := regexp.MustCompile(`[+#.<>\-_()*]`)
+
+	// Extract key:value pairs
+	keyValues := keyValueRegex.FindAllString(content, -1)
+	// Extract [tag]
+	tags := tagRegex.FindAllString(content, -1)
+
+	// Replace key:value pairs and [tag] with empty string
+	contentWithoutPatterns := keyValueRegex.ReplaceAllString(content, "")
+	contentWithoutPatterns = tagRegex.ReplaceAllString(contentWithoutPatterns, "")
+
+	// Replace characters with pattern [+#.<>_()*] with space
+	replacedContent := replaceCharsPattern.ReplaceAllString(contentWithoutPatterns, " ")
+
+	return strings.TrimSpace(replacedContent), append(keyValues, tags...)
 }
 
 type SearchCondition struct {

--- a/internal/schema/search_schema.go
+++ b/internal/schema/search_schema.go
@@ -20,11 +20,12 @@
 package schema
 
 import (
+	"regexp"
+	"strings"
+
 	"github.com/apache/incubator-answer/internal/base/constant"
 	"github.com/apache/incubator-answer/internal/base/validator"
 	"github.com/apache/incubator-answer/plugin"
-	"regexp"
-	"strings"
 )
 
 type SearchDTO struct {
@@ -40,7 +41,7 @@ type SearchDTO struct {
 func (s *SearchDTO) Check() (errField []*validator.FormErrorField, err error) {
 	// Replace special characters.
 	// Special characters will cause the search abnormal, such as search for "#" will get nearly all the content that Markdown format.
-	s.Query = regexp.MustCompile(`[+#.<>\-_()*]`).ReplaceAllString(s.Query, " ")
+	s.Query = regexp.MustCompile(`[+#.<>_()*]`).ReplaceAllString(s.Query, " ")
 	s.Query = regexp.MustCompile(`\s+`).ReplaceAllString(s.Query, " ")
 	s.Query = strings.TrimSpace(s.Query)
 	return nil, nil

--- a/internal/schema/search_schema_test.go
+++ b/internal/schema/search_schema_test.go
@@ -1,0 +1,22 @@
+package schema
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReplaceSearchContent(t *testing.T) {
+	content := "user:aaa [tag] ssssfdfdf-as#fsadf"
+	replacedContent, patterns := ReplaceSearchContent(content)
+	ret := strings.Join(append(patterns, replacedContent), " ")
+
+	assert.Equal(t, "user:aaa [tag]ssssfdfdf as fsadf", ret)
+
+	content = "user:aaa-sss [tag1] ssssfdfdf-as#fsadf [tag2] score:3"
+	replacedContent, patterns = ReplaceSearchContent(content)
+	ret = strings.Join(append(patterns, replacedContent), " ")
+
+	assert.Equal(t, "user:aaa-sss score:3 [tag1] [tag2] ssssfdfdf as fsadf", ret)
+}

--- a/internal/schema/search_schema_test.go
+++ b/internal/schema/search_schema_test.go
@@ -12,7 +12,7 @@ func TestReplaceSearchContent(t *testing.T) {
 	replacedContent, patterns := ReplaceSearchContent(content)
 	ret := strings.Join(append(patterns, replacedContent), " ")
 
-	assert.Equal(t, "user:aaa [tag]ssssfdfdf as fsadf", ret)
+	assert.Equal(t, "user:aaa [tag] ssssfdfdf as fsadf", ret)
 
 	content = "user:aaa-sss [tag1] ssssfdfdf-as#fsadf [tag2] score:3"
 	replacedContent, patterns = ReplaceSearchContent(content)


### PR DESCRIPTION
Close #819 . Need @LinkinStars 's help to review if we could remove replacing '-' with ' ' for search, or any better solution.
![image](https://github.com/apache/incubator-answer/assets/11908658/1978441b-25a8-499f-a1f2-3b4e4fa301e1)
