### PR TITLE
feat: filter the same question in similar questions

### DIFF
--- a/internal/service/question_service.go
+++ b/internal/service/question_service.go
@@ -1235,7 +1235,17 @@ func (qs *QuestionService) SimilarQuestion(ctx context.Context, questionID strin
 		search.Tag = tagNames[0]
 	}
 	search.LoginUserID = loginUserID
-	return qs.GetQuestionPage(ctx, search)
+	similarQuestions, _ , err := qs.GetQuestionPage(ctx, search)
+	if err !=nil {
+		return nil, 0, err
+	}
+	var result []*schema.QuestionPageResp
+  for _, v := range similarQuestions {
+      if v.ID != questionID {
+          result = append(result, v)
+      }
+  }
+	return result, int64(len(result)), nil
 }
 
 // GetQuestionPage query questions page


### PR DESCRIPTION
I would like to offer a small suggestion regarding the user experience. Currently, the related questions during a search do not seem to exclude the current issue itself. I'm not sure if this may cause some confusion for other users, but I personally prefer to have the current problem excluded from the "related questions" to enhance the browsing experience.
Before：
![image](https://github.com/apache/incubator-answer/assets/58644520/f11baf08-bae4-44e2-96e0-37763a3557b0)
After:
![image](https://github.com/apache/incubator-answer/assets/58644520/e14cdcdf-8adb-4058-bace-1d65408f991f)
