### PR TITLE
Feat/base url config

### DIFF
--- a/internal/base/constant/site_info.go
+++ b/internal/base/constant/site_info.go
@@ -48,5 +48,6 @@ const (
 )
 
 var (
-	PublicUrl = os.Getenv("PUBLIC_URL")
+	PublicUrl   = os.Getenv("PUBLIC_URL")
+	BaseUrlPath = os.Getenv("REACT_APP_BASE_URL_PATH")
 )

--- a/internal/base/constant/site_info.go
+++ b/internal/base/constant/site_info.go
@@ -19,6 +19,8 @@
 
 package constant
 
+import "os"
+
 const (
 	DefaultGravatarBaseURL = "https://www.gravatar.com/avatar/"
 	DefaultAvatar          = "system"
@@ -43,4 +45,8 @@ const (
 	ColorSchemeLight   = "light"
 	ColorSchemeDark    = "dark"
 	ColorSchemeSystem  = "system"
+)
+
+var (
+	PublicUrl = os.Getenv("PUBLIC_URL")
 )

--- a/internal/install/install_controller.go
+++ b/internal/install/install_controller.go
@@ -20,6 +20,7 @@
 package install
 
 import (
+	"github.com/apache/incubator-answer/internal/base/constant"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -60,9 +61,9 @@ func LangOptions(ctx *gin.Context) {
 // @Router / [get]
 func CheckConfigFileAndRedirectToInstallPage(ctx *gin.Context) {
 	if cli.CheckConfigFile(confPath) {
-		ctx.Redirect(http.StatusFound, "/50x")
+		ctx.Redirect(http.StatusFound, constant.BaseUrlPath+"/50x")
 	} else {
-		ctx.Redirect(http.StatusFound, "/install")
+		ctx.Redirect(http.StatusFound, constant.BaseUrlPath+"/install")
 	}
 }
 

--- a/internal/install/install_main.go
+++ b/internal/install/install_main.go
@@ -21,6 +21,7 @@ package install
 
 import (
 	"fmt"
+	"github.com/apache/incubator-answer/internal/base/constant"
 	"os"
 
 	"github.com/apache/incubator-answer/internal/base/translator"
@@ -49,7 +50,7 @@ func Run(configPath string) {
 	if len(port) == 0 {
 		port = "80"
 	}
-	fmt.Printf("[SUCCESS] answer installation service will run at: http://localhost:%s/install/ \n", port)
+	fmt.Printf("[SUCCESS] answer installation service will run at: http://localhost:%s%s/install/ \n", port, constant.BaseUrlPath)
 	if err = installServer.Run(":" + port); err != nil {
 		panic(err)
 	}

--- a/internal/install/install_server.go
+++ b/internal/install/install_server.go
@@ -22,6 +22,7 @@ package install
 import (
 	"embed"
 	"fmt"
+	"github.com/apache/incubator-answer/internal/base/constant"
 	"io/fs"
 	"net/http"
 
@@ -48,7 +49,7 @@ func NewInstallHTTPServer() *gin.Engine {
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()
 	r.GET("/healthz", func(ctx *gin.Context) { ctx.String(200, "OK") })
-	r.StaticFS("/static", http.FS(&_resource{
+	r.StaticFS(constant.PublicUrl+"/static", http.FS(&_resource{
 		fs: ui.Build,
 	}))
 

--- a/internal/install/install_server.go
+++ b/internal/install/install_server.go
@@ -23,12 +23,11 @@ import (
 	"embed"
 	"fmt"
 	"github.com/apache/incubator-answer/internal/base/constant"
-	"io/fs"
-	"net/http"
-
 	"github.com/apache/incubator-answer/ui"
 	"github.com/gin-gonic/gin"
 	"github.com/segmentfault/pacman/log"
+	"io/fs"
+	"net/http"
 )
 
 const UIStaticPath = "build/static"
@@ -54,9 +53,9 @@ func NewInstallHTTPServer() *gin.Engine {
 	}))
 
 	installApi := r.Group("")
-	installApi.GET("/", CheckConfigFileAndRedirectToInstallPage)
-	installApi.GET("/install", WebPage)
-	installApi.GET("/50x", WebPage)
+	installApi.GET(constant.BaseUrlPath+"/", CheckConfigFileAndRedirectToInstallPage)
+	installApi.GET(constant.BaseUrlPath+"/install", WebPage)
+	installApi.GET(constant.BaseUrlPath+"/50x", WebPage)
 	installApi.GET("/installation/language/options", LangOptions)
 	installApi.POST("/installation/db/check", CheckDatabase)
 	installApi.POST("/installation/config-file/check", CheckConfigFile)

--- a/internal/migrations/init_data.go
+++ b/internal/migrations/init_data.go
@@ -20,23 +20,24 @@
 package migrations
 
 import (
+	"github.com/apache/incubator-answer/internal/base/constant"
 	"github.com/apache/incubator-answer/internal/entity"
 	"github.com/apache/incubator-answer/internal/service/permission"
 )
 
-const (
+var (
 	defaultSEORobotTxt = `User-agent: *
-Disallow: /admin
-Disallow: /search
-Disallow: /install
-Disallow: /review
-Disallow: /users/login
-Disallow: /users/register
-Disallow: /users/account-recovery
-Disallow: /users/oauth/*
-Disallow: /users/*/*
-Disallow: /answer/api
-Disallow: /*?code*
+Disallow: ` + constant.BaseUrlPath + `/admin
+Disallow: ` + constant.BaseUrlPath + `/search
+Disallow: ` + constant.BaseUrlPath + `/install
+Disallow: ` + constant.BaseUrlPath + `/review
+Disallow: ` + constant.BaseUrlPath + `/users/login
+Disallow: ` + constant.BaseUrlPath + `/users/register
+Disallow: ` + constant.BaseUrlPath + `/users/account-recovery
+Disallow: ` + constant.BaseUrlPath + `/users/oauth/*
+Disallow: ` + constant.BaseUrlPath + `/users/*/*
+Disallow: ` + constant.BaseUrlPath + `/answer/api
+Disallow: ` + constant.BaseUrlPath + `/*?code*
 
 Sitemap: `
 )

--- a/internal/router/ui.go
+++ b/internal/router/ui.go
@@ -102,7 +102,7 @@ func (a *UIRouter) Register(r *gin.Engine) {
 		urlPath := c.Request.URL.Path
 		filePath := ""
 		switch urlPath {
-		case "/favicon.ico":
+		case constant.BaseUrlPath + "/favicon.ico":
 			branding, err := a.siteInfoService.GetSiteBranding(c)
 			if err != nil {
 				log.Error(err)
@@ -118,13 +118,13 @@ func (a *UIRouter) Register(r *gin.Engine) {
 				filePath = UIRootFilePath + urlPath
 
 			}
-		case "/manifest.json":
+		case constant.BaseUrlPath + "/manifest.json":
 			// filePath = UIRootFilePath + urlPath
 			a.siteInfoController.GetManifestJson(c)
 			return
-		case "/install":
+		case constant.BaseUrlPath + "/install":
 			// if answer is running by run command user can not access install page.
-			c.Redirect(http.StatusFound, "/")
+			c.Redirect(http.StatusFound, constant.BaseUrlPath+"/")
 			return
 		default:
 			filePath = UIIndexFilePath

--- a/internal/router/ui.go
+++ b/internal/router/ui.go
@@ -22,6 +22,7 @@ package router
 import (
 	"embed"
 	"fmt"
+	"github.com/apache/incubator-answer/internal/base/constant"
 	"io/fs"
 	"net/http"
 	"os"
@@ -92,7 +93,7 @@ func (a *UIRouter) Register(r *gin.Engine) {
 	}
 
 	// handle the static file by default ui static files
-	r.StaticFS("/static", http.FS(&_resource{
+	r.StaticFS(constant.PublicUrl+"/static", http.FS(&_resource{
 		fs: ui.Build,
 	}))
 

--- a/ui/src/components/AccordionNav/index.tsx
+++ b/ui/src/components/AccordionNav/index.tsx
@@ -27,13 +27,14 @@ import classNames from 'classnames';
 import { floppyNavigation } from '@/utils';
 import { Icon } from '@/components';
 import './index.css';
+import { BASE_URL_PATH } from '@/router/alias';
 
 function MenuNode({
   menu,
   callback,
   activeKey,
   expanding = false,
-  path = '/',
+  path = `${BASE_URL_PATH}/`,
 }) {
   const { t } = useTranslation('translation', { keyPrefix: 'nav_menus' });
   const isLeaf = !menu.children.length;

--- a/ui/src/components/BaseUserCard/index.tsx
+++ b/ui/src/components/BaseUserCard/index.tsx
@@ -22,6 +22,7 @@ import { Link } from 'react-router-dom';
 
 import { Avatar } from '@/components';
 import { formatCount } from '@/utils';
+import { BASE_URL_PATH } from '@/router/alias';
 
 interface Props {
   data: any;
@@ -48,7 +49,7 @@ const Index: FC<Props> = ({
     <div className={`d-flex align-items-center  text-secondary ${className}`}>
       {data?.status !== 'deleted' ? (
         <Link
-          to={`/users/${data?.username}`}
+          to={`${BASE_URL_PATH}/users/${data?.username}`}
           className="d-flex align-items-center">
           {showAvatar && (
             <Avatar

--- a/ui/src/components/Comment/components/ActionBar/index.tsx
+++ b/ui/src/components/Comment/components/ActionBar/index.tsx
@@ -25,6 +25,7 @@ import { Link } from 'react-router-dom';
 import classNames from 'classnames';
 
 import { Icon, FormatTime } from '@/components';
+import { BASE_URL_PATH } from '@/router/alias';
 
 const ActionBar = ({
   nickName,
@@ -45,7 +46,7 @@ const ActionBar = ({
       <div className="d-flex align-items-center flex-wrap link-secondary">
         {userStatus !== 'deleted' ? (
           <Link
-            to={`/users/${username}`}
+            to={`${BASE_URL_PATH}/users/${username}`}
             className="name-ellipsis"
             style={{ maxWidth: '200px' }}>
             {nickName}

--- a/ui/src/components/Header/components/NavItems/index.tsx
+++ b/ui/src/components/Header/components/NavItems/index.tsx
@@ -26,6 +26,7 @@ import type * as Type from '@/common/interface';
 import { Avatar, Icon } from '@/components';
 import { floppyNavigation } from '@/utils';
 import { userCenterStore } from '@/stores';
+import { BASE_URL_PATH } from '@/router/alias';
 
 interface Props {
   redDot: Type.NotificationStatus | undefined;
@@ -50,7 +51,7 @@ const Index: FC<Props> = ({ redDot, userInfo, logOut }) => {
       <Nav className="flex-row">
         <Nav.Link
           as={NavLink}
-          to="/users/notifications/inbox"
+          to={`${BASE_URL_PATH}/users/notifications/inbox`}
           title={t('inbox', { keyPrefix: 'notifications' })}
           className="icon-link d-flex align-items-center justify-content-center p-0 me-3 position-relative">
           <Icon name="bell-fill" className="fs-4" />
@@ -65,7 +66,7 @@ const Index: FC<Props> = ({ redDot, userInfo, logOut }) => {
 
         <Nav.Link
           as={NavLink}
-          to="/users/notifications/achievement"
+          to={`${BASE_URL_PATH}/users/notifications/achievement`}
           title={t('achievement', { keyPrefix: 'notifications' })}
           className="icon-link d-flex align-items-center justify-content-center p-0 me-3 position-relative">
           <Icon name="trophy-fill" className="fs-4" />
@@ -96,22 +97,24 @@ const Index: FC<Props> = ({ redDot, userInfo, logOut }) => {
 
         <Dropdown.Menu>
           <Dropdown.Item
-            href={`/users/${userInfo.username}`}
+            href={`${BASE_URL_PATH}/users/${userInfo.username}`}
             onClick={handleLinkClick}>
             {t('header.nav.profile')}
           </Dropdown.Item>
           <Dropdown.Item
-            href={`/users/${userInfo.username}/bookmarks`}
+            href={`${BASE_URL_PATH}/users/${userInfo.username}/bookmarks`}
             onClick={handleLinkClick}>
             {t('header.nav.bookmark')}
           </Dropdown.Item>
           <Dropdown.Item
-            href="/users/settings/profile"
+            href={`${BASE_URL_PATH}/users/settings/profile`}
             onClick={handleLinkClick}>
             {t('header.nav.setting')}
           </Dropdown.Item>
           <Dropdown.Divider />
-          <Dropdown.Item href="/users/logout" onClick={(e) => logOut(e)}>
+          <Dropdown.Item
+            href={`${BASE_URL_PATH}/users/logout`}
+            onClick={(e) => logOut(e)}>
             {t('header.nav.logout')}
           </Dropdown.Item>
         </Dropdown.Menu>

--- a/ui/src/components/Header/index.tsx
+++ b/ui/src/components/Header/index.tsx
@@ -48,6 +48,7 @@ import {
   sideNavStore,
 } from '@/stores';
 import { logout, useQueryNotificationStatus } from '@/services';
+import { BASE_URL_PATH } from '@/router/alias';
 
 import NavItems from './components/NavItems';
 
@@ -70,7 +71,7 @@ const Header: FC = () => {
    * Automatically append `tag` information when creating a question
    */
   const tagMatch = useMatch('/tags/:slugName');
-  let askUrl = '/questions/ask';
+  let askUrl = `${BASE_URL_PATH}/questions/ask`;
   if (tagMatch && tagMatch.params.slugName) {
     askUrl = `${askUrl}?tags=${encodeURIComponent(tagMatch.params.slugName)}`;
   }
@@ -90,7 +91,9 @@ const Header: FC = () => {
     if (!searchStr) {
       return;
     }
-    const searchUrl = `/search?q=${encodeURIComponent(searchStr)}`;
+    const searchUrl = `${BASE_URL_PATH}/search?q=${encodeURIComponent(
+      searchStr,
+    )}`;
     navigate(searchUrl);
   };
 
@@ -145,7 +148,10 @@ const Header: FC = () => {
         />
 
         <div className="d-flex justify-content-between align-items-center nav-grow flex-nowrap">
-          <Navbar.Brand to="/" as={Link} className="lh-1 me-0 me-sm-5 p-0">
+          <Navbar.Brand
+            to={`${BASE_URL_PATH}/`}
+            as={Link}
+            className="lh-1 me-0 me-sm-5 p-0">
             {brandingInfo.logo ? (
               <>
                 <img
@@ -240,7 +246,6 @@ const Header: FC = () => {
                     {t('btns.add_question')}
                   </Link>
                 </Nav.Item>
-
                 <NavItems
                   redDot={redDot}
                   userInfo={user}

--- a/ui/src/components/HttpErrorContent/index.tsx
+++ b/ui/src/components/HttpErrorContent/index.tsx
@@ -22,6 +22,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import { usePageTags } from '@/hooks';
+import { BASE_URL_PATH } from '@/router/alias';
 
 const Index = ({
   httpCode = '',
@@ -63,7 +64,7 @@ const Index = ({
         {errMsg || t(`desc_${httpCode}`)}
       </div>
       <div className="text-center">
-        <Link to="/" className="btn btn-link">
+        <Link to={`${BASE_URL_PATH}/`} className="btn btn-link">
           {t('back_home')}
         </Link>
       </div>

--- a/ui/src/components/Modal/LoginToContinueModal.tsx
+++ b/ui/src/components/Modal/LoginToContinueModal.tsx
@@ -25,6 +25,7 @@ import { Link } from 'react-router-dom';
 import { loginToContinueStore, siteInfoStore } from '@/stores';
 import { floppyNavigation } from '@/utils';
 import { WelcomeTitle } from '@/components';
+import { BASE_URL_PATH } from '@/router/alias';
 
 interface IProps {
   visible: boolean;
@@ -59,13 +60,13 @@ const Index: React.FC<IProps> = ({ visible = false }) => {
         </div>
         <div className="d-grid gap-2">
           <Link
-            to="/users/login"
+            to={`${BASE_URL_PATH}/users/login`}
             className="btn btn-primary"
             onClick={linkClick}>
             {t('login', { keyPrefix: 'btns' })}
           </Link>
           <Link
-            to="/users/register"
+            to={`${BASE_URL_PATH}/users/register`}
             className="btn btn-link"
             onClick={linkClick}>
             {t('signup', { keyPrefix: 'btns' })}

--- a/ui/src/components/Operate/index.tsx
+++ b/ui/src/components/Operate/index.tsx
@@ -38,6 +38,7 @@ import {
 import { tryNormalLogged } from '@/utils/guard';
 import { floppyNavigation } from '@/utils';
 import { toastStore } from '@/stores';
+import { BASE_URL_PATH } from '@/router/alias';
 
 interface IProps {
   type: 'answer' | 'question';
@@ -70,7 +71,9 @@ const Index: FC<IProps> = ({
   };
   const closeModal = useReportModal(refreshQuestion);
   const editUrl =
-    type === 'answer' ? `/posts/${qid}/${aid}/edit` : `/posts/${qid}/edit`;
+    type === 'answer'
+      ? `${BASE_URL_PATH}/posts/${qid}/${aid}/edit`
+      : `${BASE_URL_PATH}/posts/${qid}/edit`;
 
   const handleReport = () => {
     reportModal.onShow({

--- a/ui/src/components/QuestionList/index.tsx
+++ b/ui/src/components/QuestionList/index.tsx
@@ -36,6 +36,7 @@ import {
   Icon,
 } from '@/components';
 import * as Type from '@/common/interface';
+import { BASE_URL_PATH } from '@/router/alias';
 
 export const QUESTION_ORDER_KEYS: Type.QuestionOrderBy[] = [
   'active',
@@ -75,7 +76,7 @@ const QuestionList: FC<Props> = ({
         <QueryGroup
           data={QUESTION_ORDER_KEYS}
           currentSort={curOrder}
-          pathname={source === 'questions' ? '/questions' : ''}
+          pathname={source === 'questions' ? `${BASE_URL_PATH}/questions` : ''}
           i18nKeyPrefix="question"
         />
       </div>
@@ -147,7 +148,7 @@ const QuestionList: FC<Props> = ({
           currentPage={curPage}
           totalSize={count}
           pageSize={pageSize}
-          pathname={source === 'questions' ? '/questions' : ''}
+          pathname={source === 'questions' ? `${BASE_URL_PATH}/questions` : ''}
         />
       </div>
     </div>

--- a/ui/src/components/Share/index.tsx
+++ b/ui/src/components/Share/index.tsx
@@ -25,6 +25,7 @@ import { FacebookShareButton, TwitterShareButton } from 'next-share';
 import copy from 'copy-to-clipboard';
 
 import { loggedUserInfoStore } from '@/stores';
+import { BASE_URL_PATH } from '@/router/alias';
 
 interface IProps {
   type: 'answer' | 'question';
@@ -42,8 +43,8 @@ const Index: FC<IProps> = ({ type, qid, aid, title }) => {
   const { t } = useTranslation();
   let baseUrl =
     type === 'question'
-      ? `${window.location.origin}/questions/${qid}`
-      : `${window.location.origin}/questions/${qid}/${aid}`;
+      ? `${window.location.origin}${BASE_URL_PATH}/questions/${qid}`
+      : `${window.location.origin}${BASE_URL_PATH}/questions/${qid}/${aid}`;
   if (user.id) {
     baseUrl = `${baseUrl}?shareUserId=${user.username}`;
   }

--- a/ui/src/components/SideNav/index.tsx
+++ b/ui/src/components/SideNav/index.tsx
@@ -27,6 +27,7 @@ import classnames from 'classnames';
 import { loggedUserInfoStore, sideNavStore } from '@/stores';
 import { Icon } from '@/components';
 import './index.scss';
+import { BASE_URL_PATH } from '@/router/alias';
 
 const Index: FC = () => {
   const { t } = useTranslation();
@@ -52,7 +53,7 @@ const Index: FC = () => {
       <div className="nav-wrap pt-4">
         <Nav variant="pills" className="flex-column">
           <NavLink
-            to="/questions"
+            to={`${BASE_URL_PATH}/questions`}
             className={({ isActive }) =>
               isActive || pathname === '/' ? 'nav-link active' : 'nav-link'
             }>
@@ -61,14 +62,14 @@ const Index: FC = () => {
           </NavLink>
 
           <Nav.Link
-            href="/tags"
-            active={pathname === '/tags'}
-            onClick={(e) => handleNavClick(e, '/tags')}>
+            href={`${BASE_URL_PATH}/tags`}
+            active={pathname === `${BASE_URL_PATH}/tags`}
+            onClick={(e) => handleNavClick(e, `${BASE_URL_PATH}/tags`)}>
             <Icon name="tags-fill" className="me-2" />
             <span>{t('header.nav.tag')}</span>
           </Nav.Link>
 
-          <NavLink to="/users" className="nav-link">
+          <NavLink to={`${BASE_URL_PATH}/users`} className="nav-link">
             <Icon name="people-fill" className="me-2" />
             <span>{t('header.nav.user')}</span>
           </NavLink>
@@ -79,7 +80,7 @@ const Index: FC = () => {
                 {t('header.nav.moderation')}
               </div>
               {can_revision && (
-                <NavLink to="/review" className="nav-link">
+                <NavLink to={`${BASE_URL_PATH}/review`} className="nav-link">
                   <span>{t('header.nav.review')}</span>
                   <span className="float-end">
                     {revision > 99 ? '99+' : revision > 0 ? revision : ''}
@@ -88,7 +89,7 @@ const Index: FC = () => {
               )}
 
               {userInfo?.role_id === 2 ? (
-                <NavLink to="/admin" className="nav-link">
+                <NavLink to={`${BASE_URL_PATH}/admin`} className="nav-link">
                   {t('header.nav.admin')}
                 </NavLink>
               ) : null}

--- a/ui/src/components/Unactivate/index.tsx
+++ b/ui/src/components/Unactivate/index.tsx
@@ -27,6 +27,7 @@ import { loggedUserInfoStore } from '@/stores';
 import { resendEmail } from '@/services';
 import { handleFormError } from '@/utils';
 import { useCaptchaModal } from '@/hooks';
+import { BASE_URL_PATH } from '@/router/alias';
 
 interface IProps {
   visible?: boolean;
@@ -99,7 +100,10 @@ const Index: React.FC<IProps> = () => {
           <Button variant="link" onClick={onSentEmail}>
             {t('btn_name')}
           </Button>
-          <Link to="/users/change-email" replace className="btn btn-link ms-2">
+          <Link
+            to={`${BASE_URL_PATH}/users/change-email`}
+            replace
+            className="btn btn-link ms-2">
             {t('change_btn_name')}
           </Link>
         </>

--- a/ui/src/components/UserCard/index.tsx
+++ b/ui/src/components/UserCard/index.tsx
@@ -24,6 +24,7 @@ import classnames from 'classnames';
 
 import { Avatar, FormatTime } from '@/components';
 import { formatCount } from '@/utils';
+import { BASE_URL_PATH } from '@/router/alias';
 
 interface Props {
   data: any;
@@ -45,7 +46,7 @@ const Index: FC<Props> = ({
   return (
     <div className={classnames('d-flex', className)}>
       {data?.status !== 'deleted' ? (
-        <Link to={`/users/${data?.username}`}>
+        <Link to={`${BASE_URL_PATH}/users/${data?.username}`}>
           <Avatar
             avatar={data?.avatar}
             size="40px"
@@ -85,7 +86,7 @@ const Index: FC<Props> = ({
         <div className="me-1 me-md-0 d-flex align-items-center">
           {data?.status !== 'deleted' ? (
             <Link
-              to={`/users/${data?.username}`}
+              to={`${BASE_URL_PATH}/users/${data?.username}`}
               className="me-1 text-break name-ellipsis"
               style={{ maxWidth: '100px' }}>
               {data?.display_name}

--- a/ui/src/pages/Admin/Dashboard/components/HealthStatus/index.tsx
+++ b/ui/src/pages/Admin/Dashboard/components/HealthStatus/index.tsx
@@ -23,6 +23,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 
 import type * as Type from '@/common/interface';
+import { BASE_URL_PATH } from '@/router/alias';
 
 const { gt, gte } = require('semver');
 
@@ -98,7 +99,7 @@ const HealthStatus: FC<IProps> = ({ data }) => {
             {data.smtp !== 'not_configured' ? (
               <strong>{t(data.smtp)}</strong>
             ) : (
-              <Link to="/admin/smtp" className="ms-2">
+              <Link to={`${BASE_URL_PATH}/admin/smtp`} className="ms-2">
                 {t('config')}
               </Link>
             )}

--- a/ui/src/pages/Admin/Dashboard/components/Statistics/index.tsx
+++ b/ui/src/pages/Admin/Dashboard/components/Statistics/index.tsx
@@ -23,6 +23,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 
 import type * as Type from '@/common/interface';
+import { BASE_URL_PATH } from '@/router/alias';
 
 interface IProps {
   data: Type.AdminDashboard['info'];
@@ -58,7 +59,7 @@ const Statistics: FC<IProps> = ({ data }) => {
           <Col xs={6}>
             <span className="text-secondary me-1">{t('flags')}</span>
             <strong>
-              <Link to="/admin/flags" className="ms-2">
+              <Link to={`${BASE_URL_PATH}/admin/flags`} className="ms-2">
                 {data.report_count}
               </Link>
             </strong>

--- a/ui/src/pages/Admin/Plugins/Installed/index.tsx
+++ b/ui/src/pages/Admin/Plugins/Installed/index.tsx
@@ -28,6 +28,7 @@ import { Empty, QueryGroup, Icon } from '@/components';
 import * as Type from '@/common/interface';
 import { useQueryPlugins, updatePluginStatus } from '@/services';
 import PluginKit from '@/utils/pluginKit';
+import { BASE_URL_PATH } from '@/router/alias';
 
 const InstalledPluginsFilterKeys: Type.InstalledPluginsFilterBy[] = [
   'all',
@@ -73,7 +74,7 @@ const Users: FC = () => {
     });
   };
   const handleSettings = (plugin) => {
-    const url = `/admin/${plugin.slug_name}`;
+    const url = `${BASE_URL_PATH}/admin/${plugin.slug_name}`;
     navigate(url);
   };
 

--- a/ui/src/pages/Admin/Questions/index.tsx
+++ b/ui/src/pages/Admin/Questions/index.tsx
@@ -36,6 +36,7 @@ import { ADMIN_LIST_STATUS } from '@/common/constants';
 import * as Type from '@/common/interface';
 import { useQuestionSearch } from '@/services';
 import { pathFactory } from '@/router/pathFactory';
+import { BASE_URL_PATH } from '@/router/alias';
 
 import Action from './components/Action';
 
@@ -125,7 +126,7 @@ const Questions: FC = () => {
                 <td>{li.vote_count}</td>
                 <td>
                   <Link
-                    to={`/admin/answers?questionId=${li.id}`}
+                    to={`${BASE_URL_PATH}/admin/answers?questionId=${li.id}`}
                     rel="noreferrer">
                     {li.answer_count}
                   </Link>

--- a/ui/src/pages/Admin/index.tsx
+++ b/ui/src/pages/Admin/index.tsx
@@ -29,7 +29,7 @@ import { AccordionNav } from '@/components';
 import { ADMIN_NAV_MENUS } from '@/common/constants';
 import { useQueryPlugins } from '@/services';
 import { interfaceStore } from '@/stores';
-
+import { BASE_URL_PATH } from '@/router/alias';
 import './index.scss';
 
 const g10Paths = [
@@ -97,7 +97,7 @@ const Index: FC = () => {
       <Container className="admin-container">
         <Row>
           <Col lg={2}>
-            <AccordionNav menus={menus} path="/admin/" />
+            <AccordionNav menus={menus} path={`${BASE_URL_PATH}/admin/`} />
           </Col>
           <Col lg={g10Paths.find((v) => curPath === v) ? 10 : 6}>
             <Outlet />

--- a/ui/src/pages/Install/index.tsx
+++ b/ui/src/pages/Install/index.tsx
@@ -31,6 +31,7 @@ import {
 } from '@/services';
 import { Storage, handleFormError, scrollToDocTop } from '@/utils';
 import { CURRENT_LANG_STORAGE_KEY } from '@/common/constants';
+import { BASE_URL_PATH } from '@/router/alias';
 
 import {
   FirstStep,
@@ -312,7 +313,7 @@ const Index: FC = () => {
 
                   <Fifth
                     visible={step === 5}
-                    siteUrl={formData.site_url.value}
+                    siteUrl={formData.site_url.value + BASE_URL_PATH}
                   />
                   {step === 6 && (
                     <div>

--- a/ui/src/pages/Layout/index.tsx
+++ b/ui/src/pages/Layout/index.tsx
@@ -44,7 +44,7 @@ const Layout: FC = () => {
   };
   const { code: httpStatusCode, reset: httpStatusReset } = errorCodeStore();
   const { show: showLoginToContinueModal } = loginToContinueStore();
-
+  console.log('lyz:', location);
   useEffect(() => {
     httpStatusReset();
   }, [location]);

--- a/ui/src/pages/Legal/index.tsx
+++ b/ui/src/pages/Legal/index.tsx
@@ -22,6 +22,8 @@ import { Row, Col, Nav } from 'react-bootstrap';
 import { Outlet, NavLink } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
+import { BASE_URL_PATH } from '@/router/alias';
+
 const Index: FC = () => {
   const { t } = useTranslation('translation', { keyPrefix: 'nav_menus' });
   return (
@@ -31,10 +33,13 @@ const Index: FC = () => {
           className="mb-4 flex-nowrap"
           variant="pills"
           style={{ overflow: 'auto' }}>
-          <NavLink to="/tos" key="tos" className="nav-link">
+          <NavLink to={`${BASE_URL_PATH}/tos`} key="tos" className="nav-link">
             {t('tos')}
           </NavLink>
-          <NavLink to="/privacy" key="privacy" className="nav-link">
+          <NavLink
+            to={`${BASE_URL_PATH}/privacy`}
+            key="privacy"
+            className="nav-link">
             {t('privacy')}
           </NavLink>
         </Nav>

--- a/ui/src/pages/Questions/Detail/components/Answer/index.tsx
+++ b/ui/src/pages/Questions/Detail/components/Answer/index.tsx
@@ -36,6 +36,7 @@ import { scrollToElementTop, bgFadeOut } from '@/utils';
 import { AnswerItem } from '@/common/interface';
 import { acceptanceAnswer } from '@/services';
 import { useRenderHtmlPlugin } from '@/utils/pluginKit';
+import { BASE_URL_PATH } from '@/router/alias';
 
 interface Props {
   data: AnswerItem;
@@ -163,10 +164,11 @@ const Index: FC<Props> = ({
               time={Number(data.update_time)}
               preFix={t('edit')}
               isLogged={isLogged}
-              timelinePath={`/posts/${data.question_id}/${data.id}/timeline`}
+              timelinePath={`${BASE_URL_PATH}/posts/${data.question_id}/${data.id}/timeline`}
             />
           ) : isLogged ? (
-            <Link to={`/posts/${data.question_id}/${data.id}/timeline`}>
+            <Link
+              to={`${BASE_URL_PATH}/posts/${data.question_id}/${data.id}/timeline`}>
               <FormatTime
                 time={Number(data.update_time)}
                 preFix={t('edit')}

--- a/ui/src/pages/Questions/Detail/components/InviteToAnswer/index.tsx
+++ b/ui/src/pages/Questions/Detail/components/InviteToAnswer/index.tsx
@@ -28,6 +28,7 @@ import { Avatar } from '@/components';
 import { getInviteUser, putInviteUser } from '@/services';
 import type * as Type from '@/common/interface';
 import { useCaptchaModal } from '@/hooks';
+import { BASE_URL_PATH } from '@/router/alias';
 
 import PeopleDropdown from './PeopleDropdown';
 
@@ -127,7 +128,7 @@ const Index: FC<Props> = ({ questionId, readOnly = false }) => {
             return (
               <Link
                 key={user.username}
-                to={`/users/${user.username}`}
+                to={`${BASE_URL_PATH}/users/${user.username}`}
                 className="mx-2 my-1 d-inline-flex flex-nowrap">
                 <Avatar
                   avatar={user.avatar}

--- a/ui/src/pages/Questions/Detail/components/Question/index.tsx
+++ b/ui/src/pages/Questions/Detail/components/Question/index.tsx
@@ -37,6 +37,7 @@ import { useRenderHtmlPlugin } from '@/utils/pluginKit';
 import { formatCount, guard } from '@/utils';
 import { following } from '@/services';
 import { pathFactory } from '@/router/pathFactory';
+import { BASE_URL_PATH } from '@/router/alias';
 
 interface Props {
   data: any;
@@ -186,7 +187,7 @@ const Index: FC<Props> = ({ data, initPage, hasAnswer, isLogged }) => {
               timelinePath={`/posts/${data.id}/timeline`}
             />
           ) : isLogged ? (
-            <Link to={`/posts/${data.id}/timeline`}>
+            <Link to={`${BASE_URL_PATH}/posts/${data.id}/timeline`}>
               <FormatTime
                 time={data.edit_time}
                 preFix={t('edit')}
@@ -207,7 +208,7 @@ const Index: FC<Props> = ({ data, initPage, hasAnswer, isLogged }) => {
             time={data.create_time}
             preFix={t('asked')}
             isLogged={isLogged}
-            timelinePath={`/posts/${data.id}/timeline`}
+            timelinePath={`${BASE_URL_PATH}/posts/${data.id}/timeline`}
           />
         </div>
       </div>

--- a/ui/src/pages/Questions/Detail/components/WriteAnswer/index.tsx
+++ b/ui/src/pages/Questions/Detail/components/WriteAnswer/index.tsx
@@ -32,6 +32,7 @@ import { postAnswer } from '@/services';
 import { guard, handleFormError, SaveDraft, storageExpires } from '@/utils';
 import { DRAFT_ANSWER_STORAGE_KEY } from '@/common/constants';
 import { writeSettingStore } from '@/stores';
+import { BASE_URL_PATH } from '@/router/alias';
 
 interface Props {
   visible?: boolean;
@@ -314,7 +315,7 @@ const Index: FC<Props> = ({ visible = false, data, callback }) => {
       {data.answered && !showEditor ? (
         // the 0th answer is the oldest one
         <Link
-          to={`/posts/${data.qid}/${data.first_answer_id}/edit`}
+          to={`${BASE_URL_PATH}/posts/${data.qid}/${data.first_answer_id}/edit`}
           className="btn btn-primary">
           {t('edit_answer')}
         </Link>

--- a/ui/src/pages/Questions/Detail/index.tsx
+++ b/ui/src/pages/Questions/Detail/index.tsx
@@ -37,6 +37,7 @@ import type {
   AnswerItem,
 } from '@/common/interface';
 import { questionDetail, getAnswers } from '@/services';
+import { BASE_URL_PATH } from '@/router/alias';
 
 import {
   Question,
@@ -161,6 +162,7 @@ const Index = () => {
             avatar_url: res?.last_answered_user_info?.avatar,
           },
         ]);
+        console.log('xx1', res);
         setQuestion(res);
       }
       setIsLoading(false);
@@ -172,7 +174,7 @@ const Index = () => {
   const initPage = (type: string) => {
     if (type === 'delete_question') {
       setTimeout(() => {
-        navigate('/', { replace: true });
+        navigate(`${BASE_URL_PATH}/`, { replace: true });
       }, 1000);
       return;
     }

--- a/ui/src/pages/Tags/Create/index.tsx
+++ b/ui/src/pages/Tags/Create/index.tsx
@@ -31,6 +31,7 @@ import type * as Type from '@/common/interface';
 import { createTag } from '@/services';
 import { handleFormError } from '@/utils';
 import { TAG_SLUG_NAME_MAX_LENGTH } from '@/common/constants';
+import { BASE_URL_PATH } from '@/router/alias';
 
 interface FormDataItem {
   displayName: Type.FormValue<string>;
@@ -175,9 +176,12 @@ const Index = () => {
     };
     createTag(params)
       .then((res) => {
-        navigate(`/tags/${encodeURIComponent(res.slug_name)}/info`, {
-          replace: true,
-        });
+        navigate(
+          `${BASE_URL_PATH}/tags/${encodeURIComponent(res.slug_name)}/info`,
+          {
+            replace: true,
+          },
+        );
       })
       .catch((err) => {
         if (err.isError) {

--- a/ui/src/pages/Tags/Detail/index.tsx
+++ b/ui/src/pages/Tags/Detail/index.tsx
@@ -41,6 +41,7 @@ import HotQuestions from '@/components/HotQuestions';
 import { escapeRemove, guard, Storage, scrollToDocTop } from '@/utils';
 import { pathFactory } from '@/router/pathFactory';
 import { QUESTIONS_ORDER_STORAGE_KEY } from '@/common/constants';
+import { BASE_URL_PATH } from '@/router/alias';
 
 const Index: FC = () => {
   const { t } = useTranslation('translation', { keyPrefix: 'tags' });
@@ -169,7 +170,7 @@ const Index: FC = () => {
                   </Button>
                   <Link
                     className="btn btn-outline-secondary ms-2"
-                    to="/users/settings/notify">
+                    to={`${BASE_URL_PATH}/users/settings/notify`}>
                     <Icon name="bell-fill" />
                   </Link>
                 </div>

--- a/ui/src/pages/Tags/Edit/index.tsx
+++ b/ui/src/pages/Tags/Edit/index.tsx
@@ -31,6 +31,7 @@ import { loggedUserInfoStore } from '@/stores';
 import type * as Type from '@/common/interface';
 import { TAG_SLUG_NAME_MAX_LENGTH } from '@/common/constants';
 import { useTagInfo, modifyTag, useQueryRevisions } from '@/services';
+import { BASE_URL_PATH } from '@/router/alias';
 
 interface FormDataItem {
   displayName: Type.FormValue<string>;
@@ -202,10 +203,15 @@ const Index = () => {
       edit_summary: formData.editSummary.value,
     };
     modifyTag(params).then((res) => {
-      navigate(`/tags/${encodeURIComponent(formData.slugName.value)}/info`, {
-        replace: true,
-        state: { isReview: res.wait_for_review },
-      });
+      navigate(
+        `${BASE_URL_PATH}/tags/${encodeURIComponent(
+          formData.slugName.value,
+        )}/info`,
+        {
+          replace: true,
+          state: { isReview: res.wait_for_review },
+        },
+      );
     });
   };
 

--- a/ui/src/pages/Tags/Info/index.tsx
+++ b/ui/src/pages/Tags/Info/index.tsx
@@ -36,6 +36,7 @@ import {
 } from '@/services';
 import { pathFactory } from '@/router/pathFactory';
 import { loggedUserInfoStore, toastStore } from '@/stores';
+import { BASE_URL_PATH } from '@/router/alias';
 
 const TagIntroduction = () => {
   const userInfo = loggedUserInfoStore((state) => state.user);
@@ -143,7 +144,7 @@ const TagIntroduction = () => {
       confirmBtnVariant: 'danger',
       onConfirm: () => {
         deleteTag(tagInfo.tag_id).then(() => {
-          navigate('/tags', { replace: true });
+          navigate(`${BASE_URL_PATH}/tags`, { replace: true });
         });
       },
     });
@@ -220,7 +221,7 @@ const TagIntroduction = () => {
           })}
           {isLogged && (
             <Link
-              to={`/tags/${tagInfo?.tag_id}/timeline`}
+              to={`${BASE_URL_PATH}/tags/${tagInfo?.tag_id}/timeline`}
               className={classNames(
                 'link-secondary btn-no-border p-0 small',
                 tagInfo?.member_actions?.length > 0 && 'ms-3',

--- a/ui/src/pages/Tags/index.tsx
+++ b/ui/src/pages/Tags/index.tsx
@@ -28,6 +28,7 @@ import { formatCount, escapeRemove } from '@/utils';
 import { tryNormalLogged } from '@/utils/guard';
 import { useQueryTags, following } from '@/services';
 import { loggedUserInfoStore } from '@/stores';
+import { BASE_URL_PATH } from '@/router/alias';
 
 const sortBtns = ['popular', 'name', 'newest'];
 
@@ -90,7 +91,7 @@ const Tags = () => {
             {role_id === 2 || role_id === 3 ? (
               <Link
                 className="btn btn-outline-primary btn-sm"
-                to="/tags/create">
+                to={`${BASE_URL_PATH}/tags/create`}>
                 {t('title', { keyPrefix: 'tag_modal' })}
               </Link>
             ) : null}

--- a/ui/src/pages/Timeline/components/Item/index.tsx
+++ b/ui/src/pages/Timeline/components/Item/index.tsx
@@ -26,6 +26,7 @@ import { Icon, BaseUserCard, DiffContent, FormatTime } from '@/components';
 import { TIMELINE_NORMAL_ACTIVITY_TYPE } from '@/common/constants';
 import * as Type from '@/common/interface';
 import { getTimelineDetail } from '@/services';
+import { BASE_URL_PATH } from '@/router/alias';
 
 interface Props {
   data: Type.TimelineItem;
@@ -90,7 +91,7 @@ const Index: FC<Props> = ({ data, isAdmin, objectInfo, revisionList }) => {
           )}
           {data.activity_type === 'accept' && (
             <Link
-              to={`/questions/${objectInfo.question_id}/${data?.object_id}`}>
+              to={`${BASE_URL_PATH}/questions/${objectInfo.question_id}/${data?.object_id}`}>
               {t(data.activity_type)}
             </Link>
           )}
@@ -98,7 +99,7 @@ const Index: FC<Props> = ({ data, isAdmin, objectInfo, revisionList }) => {
           {objectInfo.object_type === 'question' &&
             data.activity_type === 'answered' && (
               <Link
-                to={`/questions/${objectInfo.question_id}/${data.object_id}`}>
+                to={`${BASE_URL_PATH}/questions/${objectInfo.question_id}/${data.object_id}`}>
                 {t(data.activity_type)}
               </Link>
             )}
@@ -107,8 +108,8 @@ const Index: FC<Props> = ({ data, isAdmin, objectInfo, revisionList }) => {
             <Link
               to={
                 objectInfo.object_type === 'answer'
-                  ? `/questions/${objectInfo.question_id}/${objectInfo.answer_id}?commentId=${data.object_id}`
-                  : `/questions/${objectInfo.question_id}?commentId=${data.object_id}`
+                  ? `${BASE_URL_PATH}/questions/${objectInfo.question_id}/${objectInfo.answer_id}?commentId=${data.object_id}`
+                  : `${BASE_URL_PATH}/questions/${objectInfo.question_id}?commentId=${data.object_id}`
               }>
               {t(data.activity_type)}
             </Link>

--- a/ui/src/pages/Timeline/index.tsx
+++ b/ui/src/pages/Timeline/index.tsx
@@ -28,6 +28,7 @@ import { loggedUserInfoStore } from '@/stores';
 import { getTimelineData } from '@/services';
 import { Empty } from '@/components';
 import * as Type from '@/common/interface';
+import { BASE_URL_PATH } from '@/router/alias';
 
 import HistoryItem from './components/Item';
 
@@ -85,7 +86,7 @@ const Index: FC = () => {
   }
 
   if (timelineData?.object_info.object_type === 'tag') {
-    linkUrl = `/tags/${
+    linkUrl = `${BASE_URL_PATH}/tags/${
       timelineData?.object_info.main_tag_slug_name
         ? encodeURIComponent(timelineData?.object_info.main_tag_slug_name)
         : encodeURIComponent(timelineData?.object_info.title)

--- a/ui/src/pages/Users/ActivationResult/index.tsx
+++ b/ui/src/pages/Users/ActivationResult/index.tsx
@@ -24,6 +24,7 @@ import { useTranslation } from 'react-i18next';
 
 import { usePageTags } from '@/hooks';
 import { WelcomeTitle } from '@/components';
+import { BASE_URL_PATH } from '@/router/alias';
 
 const Index: FC = () => {
   const { t } = useTranslation('translation', { keyPrefix: 'account_result' });
@@ -40,7 +41,7 @@ const Index: FC = () => {
             <>
               <p className="text-center">{t('success')}</p>
               <div className="text-center">
-                <Link to="/">{t('link')}</Link>
+                <Link to={`${BASE_URL_PATH}/`}>{t('link')}</Link>
               </div>
             </>
           )}

--- a/ui/src/pages/Users/ActiveEmail/index.tsx
+++ b/ui/src/pages/Users/ActiveEmail/index.tsx
@@ -24,6 +24,7 @@ import { useSearchParams, useNavigate } from 'react-router-dom';
 import { usePageTags } from '@/hooks';
 import { loggedUserInfoStore } from '@/stores';
 import { activateAccount } from '@/services';
+import { BASE_URL_PATH } from '@/router/alias';
 
 const Index: FC = () => {
   const { t } = useTranslation('translation', { keyPrefix: 'page_title' });
@@ -37,11 +38,13 @@ const Index: FC = () => {
       activateAccount(encodeURIComponent(code)).then((res) => {
         updateUser(res);
         setTimeout(() => {
-          navigate('/users/account-activation/success', { replace: true });
+          navigate(`${BASE_URL_PATH}/users/account-activation/success`, {
+            replace: true,
+          });
         }, 0);
       });
     } else {
-      navigate('/', { replace: true });
+      navigate(`${BASE_URL_PATH}/`, { replace: true });
     }
   }, []);
   usePageTags({

--- a/ui/src/pages/Users/ChangeEmail/components/sendEmail.tsx
+++ b/ui/src/pages/Users/ChangeEmail/components/sendEmail.tsx
@@ -27,6 +27,7 @@ import { loggedUserInfoStore } from '@/stores';
 import { changeEmail } from '@/services';
 import { handleFormError } from '@/utils';
 import { useCaptchaModal } from '@/hooks';
+import { BASE_URL_PATH } from '@/router/alias';
 
 const Index: FC = () => {
   const { t } = useTranslation('translation', { keyPrefix: 'change_email' });
@@ -82,7 +83,7 @@ const Index: FC = () => {
         await emailCaptcha.close();
         userInfo.e_mail = formData.e_mail.value;
         updateUser(userInfo);
-        navigate('/users/login', { replace: true });
+        navigate(`${BASE_URL_PATH}/users/login`, { replace: true });
       })
       .catch((err) => {
         if (err.isError) {
@@ -106,7 +107,7 @@ const Index: FC = () => {
   };
 
   const goBack = () => {
-    navigate('/users/login?status=inactive', { replace: true });
+    navigate(`${BASE_URL_PATH}/users/login?status=inactive`, { replace: true });
   };
 
   return (

--- a/ui/src/pages/Users/ConfirmNewEmail/index.tsx
+++ b/ui/src/pages/Users/ConfirmNewEmail/index.tsx
@@ -26,6 +26,7 @@ import { usePageTags } from '@/hooks';
 import { loggedUserInfoStore } from '@/stores';
 import { changeEmailVerify } from '@/services';
 import { WelcomeTitle } from '@/components';
+import { BASE_URL_PATH } from '@/router/alias';
 
 const Index: FC = () => {
   const { t } = useTranslation('translation', { keyPrefix: 'account_result' });
@@ -63,7 +64,7 @@ const Index: FC = () => {
             <>
               <p className="text-center">{t('confirm_new_email')}</p>
               <div className="text-center">
-                <Link to="/">{t('link')}</Link>
+                <Link to={`${BASE_URL_PATH}/`}>{t('link')}</Link>
               </div>
             </>
           )}

--- a/ui/src/pages/Users/Login/index.tsx
+++ b/ui/src/pages/Users/Login/index.tsx
@@ -33,6 +33,7 @@ import {
 import { floppyNavigation, guard, handleFormError, userCenter } from '@/utils';
 import { login, UcAgent } from '@/services';
 import { setupAppTheme } from '@/utils/localize';
+import { BASE_URL_PATH } from '@/router/alias';
 
 const Index: React.FC = () => {
   const { t } = useTranslation('translation', { keyPrefix: 'login' });
@@ -207,7 +208,9 @@ const Index: React.FC = () => {
                 <Form.Group controlId="password" className="mb-3">
                   <div className="d-flex justify-content-between">
                     <Form.Label>{t('password.label')}</Form.Label>
-                    <Link to="/users/account-recovery" tabIndex={2}>
+                    <Link
+                      to={`${BASE_URL_PATH}/users/account-recovery`}
+                      tabIndex={2}>
                       <small>{t('forgot_pass')}</small>
                     </Link>
                   </div>

--- a/ui/src/pages/Users/Notifications/components/Achievements/index.tsx
+++ b/ui/src/pages/Users/Notifications/components/Achievements/index.tsx
@@ -24,7 +24,7 @@ import classNames from 'classnames';
 import { isEmpty } from 'lodash';
 
 import { Empty } from '@/components';
-
+import { BASE_URL_PATH } from '@/router/alias';
 import './index.scss';
 
 const Achievements = ({ data, handleReadNotification }) => {
@@ -42,13 +42,13 @@ const Achievements = ({ data, handleReadNotification }) => {
         let url = '';
         switch (item.object_info.object_type) {
           case 'question':
-            url = `/questions/${item.object_info.object_id}`;
+            url = `${BASE_URL_PATH}/questions/${item.object_info.object_id}`;
             break;
           case 'answer':
-            url = `/questions/${question}/${item.object_info.object_id}`;
+            url = `${BASE_URL_PATH}/questions/${question}/${item.object_info.object_id}`;
             break;
           case 'comment':
-            url = `/questions/${question}/${answer}?commentId=${comment}`;
+            url = `${BASE_URL_PATH}/questions/${question}/${answer}?commentId=${comment}`;
             break;
           default:
             url = '';

--- a/ui/src/pages/Users/Notifications/components/Inbox/index.tsx
+++ b/ui/src/pages/Users/Notifications/components/Inbox/index.tsx
@@ -25,6 +25,7 @@ import classNames from 'classnames';
 import { isEmpty } from 'lodash';
 
 import { FormatTime, Empty } from '@/components';
+import { BASE_URL_PATH } from '@/router/alias';
 
 const Inbox = ({ data, handleReadNotification }) => {
   const { t } = useTranslation('translation', { keyPrefix: 'notifications' });
@@ -42,13 +43,13 @@ const Inbox = ({ data, handleReadNotification }) => {
         let url = '';
         switch (item.object_info.object_type) {
           case 'question':
-            url = `/questions/${item.object_info.object_id}`;
+            url = `${BASE_URL_PATH}/questions/${item.object_info.object_id}`;
             break;
           case 'answer':
-            url = `/questions/${question}/${item.object_info.object_id}`;
+            url = `${BASE_URL_PATH}/questions/${question}/${item.object_info.object_id}`;
             break;
           case 'comment':
-            url = `/questions/${question}/${answer}?commentId=${comment}`;
+            url = `${BASE_URL_PATH}/questions/${question}/${answer}?commentId=${comment}`;
             break;
           default:
             url = '';
@@ -62,7 +63,7 @@ const Inbox = ({ data, handleReadNotification }) => {
             )}>
             <div>
               {item.user_info && item.user_info.status !== 'deleted' ? (
-                <Link to={`/users/${item.user_info.username}`}>
+                <Link to={`${BASE_URL_PATH}/users/${item.user_info.username}`}>
                   {item.user_info.display_name}{' '}
                 </Link>
               ) : (

--- a/ui/src/pages/Users/Notifications/index.tsx
+++ b/ui/src/pages/Users/Notifications/index.tsx
@@ -32,6 +32,7 @@ import {
   readNotification,
 } from '@/services';
 import { floppyNavigation } from '@/utils';
+import { BASE_URL_PATH } from '@/router/alias';
 
 import Inbox from './components/Inbox';
 import Achievements from './components/Achievements';
@@ -87,7 +88,7 @@ const Notifications = () => {
     }
     setPage(1);
     setNotificationData([]);
-    navigate(`/users/notifications/${val}`);
+    navigate(`${BASE_URL_PATH}/users/notifications/${val}`);
   };
 
   const handleLoadMore = () => {
@@ -113,7 +114,7 @@ const Notifications = () => {
           <ButtonGroup size="sm">
             <Button
               as="a"
-              href="/users/notifications/inbox"
+              href={`${BASE_URL_PATH}/users/notifications/inbox`}
               variant="outline-secondary"
               active={type === 'inbox'}
               onClick={(evt) => handleTypeChange(evt, 'inbox')}>
@@ -121,7 +122,7 @@ const Notifications = () => {
             </Button>
             <Button
               as="a"
-              href="/users/notifications/achievement"
+              href={`${BASE_URL_PATH}/users/notifications/achievement`}
               variant="outline-secondary"
               active={type === 'achievement'}
               onClick={(evt) => handleTypeChange(evt, 'achievement')}>
@@ -139,7 +140,7 @@ const Notifications = () => {
           <>
             <Nav className="inbox-nav small">
               {inboxTypeNavs.map((nav) => {
-                const navLinkHref = `/users/notifications/inbox/${nav}`;
+                const navLinkHref = `${BASE_URL_PATH}/users/notifications/inbox/${nav}`;
                 const navLinkName = t(`inbox_type.${nav}`);
                 return (
                   <Nav.Item key={nav}>

--- a/ui/src/pages/Users/OauthBindEmail/index.tsx
+++ b/ui/src/pages/Users/OauthBindEmail/index.tsx
@@ -30,6 +30,7 @@ import { oAuthBindEmail, getLoggedUserInfo } from '@/services';
 import Storage from '@/utils/storage';
 import { LOGGED_TOKEN_STORAGE_KEY } from '@/common/constants';
 import { handleFormError } from '@/utils';
+import { BASE_URL_PATH } from '@/router/alias';
 
 const Index: FC = () => {
   const { t } = useTranslation('translation', {
@@ -78,7 +79,9 @@ const Index: FC = () => {
     getLoggedUserInfo().then((user) => {
       updateUser(user);
       setTimeout(() => {
-        navigate('/users/login?status=inactive', { replace: true });
+        navigate(`${BASE_URL_PATH}/users/login?status=inactive`, {
+          replace: true,
+        });
       }, 0);
     });
   };
@@ -149,7 +152,7 @@ const Index: FC = () => {
 
   useEffect(() => {
     if (!binding_key) {
-      navigate('/', { replace: true });
+      navigate(`${BASE_URL_PATH}/`, { replace: true });
     }
   }, []);
   return (

--- a/ui/src/pages/Users/PasswordReset/index.tsx
+++ b/ui/src/pages/Users/PasswordReset/index.tsx
@@ -27,6 +27,7 @@ import { loggedUserInfoStore } from '@/stores';
 import type { FormDataType } from '@/common/interface';
 import { replacementPassword } from '@/services';
 import { handleFormError } from '@/utils';
+import { BASE_URL_PATH } from '@/router/alias';
 
 const Index: React.FC = () => {
   const { t } = useTranslation('translation', { keyPrefix: 'password_reset' });
@@ -197,7 +198,7 @@ const Index: React.FC = () => {
         <Col className="mx-auto px-4" md={6}>
           <div className="text-center">
             <p>{t('reset_success')}</p>
-            <Link to="/users/login">{t('to_login')}</Link>
+            <Link to={`${BASE_URL_PATH}/users/login`}>{t('to_login')}</Link>
           </div>
         </Col>
       )}
@@ -206,7 +207,7 @@ const Index: React.FC = () => {
         <Col className="mx-auto px-4" md={6}>
           <div className="text-center">
             <p>{t('link_invalid')}</p>
-            <Link to="/users/login">{t('to_login')}</Link>
+            <Link to={`${BASE_URL_PATH}/users/login`}>{t('to_login')}</Link>
           </div>
         </Col>
       )}

--- a/ui/src/pages/Users/Personal/components/NavBar/index.tsx
+++ b/ui/src/pages/Users/Personal/components/NavBar/index.tsx
@@ -22,6 +22,8 @@ import { Nav } from 'react-bootstrap';
 import { NavLink } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
+import { BASE_URL_PATH } from '@/router/alias';
+
 interface Props {
   slug: string;
   isSelf: boolean;
@@ -74,7 +76,7 @@ const Index: FC<Props> = ({ slug, tabName = 'overview', isSelf }) => {
         if (item.path) {
           return (
             <NavLink
-              to={`/users/${slug}${item.path}`}
+              to={`${BASE_URL_PATH}/users/${slug}${item.path}`}
               key={item.name}
               className="nav-link">
               {t(item.name)}
@@ -84,7 +86,7 @@ const Index: FC<Props> = ({ slug, tabName = 'overview', isSelf }) => {
         return (
           <NavLink
             key={item.name}
-            to={`/users/${slug}`}
+            to={`${BASE_URL_PATH}/users/${slug}`}
             className={({ isActive }) =>
               isActive && tabName === 'overview'
                 ? 'nav-link active'

--- a/ui/src/pages/Users/Personal/components/UserInfo/index.tsx
+++ b/ui/src/pages/Users/Personal/components/UserInfo/index.tsx
@@ -28,6 +28,7 @@ import { Avatar, Icon, SvgIcon } from '@/components';
 import type { UserInfoRes } from '@/common/interface';
 import { getUcBranding, UcBrandingEntry } from '@/services';
 import { userCenterStore } from '@/stores';
+import { BASE_URL_PATH } from '@/router/alias';
 
 interface Props {
   data: UserInfoRes;
@@ -57,7 +58,7 @@ const Index: FC<Props> = ({ data }) => {
   return (
     <div className="d-flex flex-column flex-md-row mb-4">
       {data?.status !== 'deleted' ? (
-        <Link to={`/users/${data.username}`} reloadDocument>
+        <Link to={`${BASE_URL_PATH}/users/${data.username}`} reloadDocument>
           <Avatar
             avatar={data.avatar}
             size="160px"
@@ -78,7 +79,7 @@ const Index: FC<Props> = ({ data }) => {
         <div className="d-flex align-items-center mb-2">
           {data?.status !== 'deleted' ? (
             <Link
-              to={`/users/${data.username}`}
+              to={`${BASE_URL_PATH}/users/${data.username}`}
               className="link-dark h3 mb-0"
               reloadDocument>
               {data.display_name}

--- a/ui/src/pages/Users/Personal/index.tsx
+++ b/ui/src/pages/Users/Personal/index.tsx
@@ -31,6 +31,7 @@ import {
   usePersonalListByTabName,
 } from '@/services';
 import type { UserInfoRes } from '@/common/interface';
+import { BASE_URL_PATH } from '@/router/alias';
 
 import {
   UserInfo,
@@ -94,7 +95,7 @@ const Personal: FC = () => {
             <div className="mb-3">
               <Link
                 className="btn btn-outline-secondary"
-                to="/users/settings/profile">
+                to={`${BASE_URL_PATH}/users/settings/profile`}>
                 {t('edit_profile')}
               </Link>
             </div>

--- a/ui/src/pages/Users/Register/components/SignUpForm/index.tsx
+++ b/ui/src/pages/Users/Register/components/SignUpForm/index.tsx
@@ -27,6 +27,7 @@ import type { FormDataType, RegisterReqParams } from '@/common/interface';
 import { register, useLegalTos, useLegalPrivacy } from '@/services';
 import userStore from '@/stores/loggedUserInfo';
 import { handleFormError } from '@/utils';
+import { BASE_URL_PATH } from '@/router/alias';
 
 interface Props {
   callback: () => void;
@@ -230,7 +231,7 @@ const Index: React.FC<Props> = ({ callback }) => {
         <Trans i18nKey="login.agreements" ns="translation">
           By registering, you agree to the
           <Link
-            to="/privacy"
+            to={`${BASE_URL_PATH}/privacy`}
             onClick={(evt) => {
               argumentClick(evt, 'privacy');
             }}
@@ -239,7 +240,7 @@ const Index: React.FC<Props> = ({ callback }) => {
           </Link>
           and
           <Link
-            to="/tos"
+            to={`${BASE_URL_PATH}/tos`}
             onClick={(evt) => {
               argumentClick(evt, 'tos');
             }}

--- a/ui/src/pages/Users/Register/index.tsx
+++ b/ui/src/pages/Users/Register/index.tsx
@@ -26,6 +26,7 @@ import { usePageTags } from '@/hooks';
 import { Unactivate, WelcomeTitle, PluginRender } from '@/components';
 import { guard } from '@/utils';
 import { loginSettingStore } from '@/stores';
+import { BASE_URL_PATH } from '@/router/alias';
 
 import SignUpForm from './components/SignUpForm';
 
@@ -62,7 +63,8 @@ const Index: React.FC = () => {
           {showSignupForm ? <SignUpForm callback={onStep} /> : null}
           <div className="text-center mt-5">
             <Trans i18nKey="login.info_login" ns="translation">
-              Already have an account? <Link to="/users/login">Log in</Link>
+              Already have an account?{' '}
+              <Link to={`${BASE_URL_PATH}/users/login`}>Log in</Link>
             </Trans>
           </div>
         </Col>

--- a/ui/src/pages/Users/Settings/components/Nav/index.tsx
+++ b/ui/src/pages/Users/Settings/components/Nav/index.tsx
@@ -23,6 +23,7 @@ import { useTranslation } from 'react-i18next';
 import { NavLink, useMatch } from 'react-router-dom';
 
 import { useGetUserPluginList } from '@/services';
+import { BASE_URL_PATH } from '@/router/alias';
 
 const Index: FC = () => {
   const { t } = useTranslation('translation', { keyPrefix: 'settings.nav' });
@@ -35,16 +36,22 @@ const Index: FC = () => {
         className={({ isActive }) =>
           isActive || !settingMatch ? 'nav-link active' : 'nav-link'
         }
-        to="/users/settings/profile">
+        to={`${BASE_URL_PATH}/users/settings/profile`}>
         {t('profile')}
       </NavLink>
-      <NavLink className="nav-link" to="/users/settings/notify">
+      <NavLink
+        className="nav-link"
+        to={`${BASE_URL_PATH}/users/settings/notify`}>
         {t('notification')}
       </NavLink>
-      <NavLink className="nav-link" to="/users/settings/account">
+      <NavLink
+        className="nav-link"
+        to={`${BASE_URL_PATH}/users/settings/account`}>
         {t('account')}
       </NavLink>
-      <NavLink className="nav-link" to="/users/settings/interface">
+      <NavLink
+        className="nav-link"
+        to={`${BASE_URL_PATH}/users/settings/interface`}>
         {t('interface')}
       </NavLink>
       {data?.map((item) => {
@@ -52,7 +59,7 @@ const Index: FC = () => {
           <NavLink
             key={item.slug_name}
             className="nav-link w-100 text-truncate"
-            to={`/users/settings/${item.slug_name}`}>
+            to={`${BASE_URL_PATH}/users/settings/${item.slug_name}`}>
             {item.name}
           </NavLink>
         );

--- a/ui/src/pages/Users/Unsubscribe/index.tsx
+++ b/ui/src/pages/Users/Unsubscribe/index.tsx
@@ -24,6 +24,7 @@ import { useTranslation } from 'react-i18next';
 
 import { unsubscribe } from '@/services';
 import { usePageTags } from '@/hooks';
+import { BASE_URL_PATH } from '@/router/alias';
 
 const Index: FC = () => {
   const { t } = useTranslation('translation', { keyPrefix: 'unsubscribe' });
@@ -44,7 +45,9 @@ const Index: FC = () => {
           <h3 className="text-center mt-3 mb-5">{t('success_title')}</h3>
           <p className="text-center">{t('success_desc')}</p>
           <div className="text-center">
-            <Link to="/users/settings/notify">{t('link')}</Link>
+            <Link to={`${BASE_URL_PATH}/users/settings/notify`}>
+              {t('link')}
+            </Link>
           </div>
         </Col>
       </Row>

--- a/ui/src/pages/Users/index.tsx
+++ b/ui/src/pages/Users/index.tsx
@@ -25,6 +25,7 @@ import { Fragment } from 'react';
 import { usePageTags } from '@/hooks';
 import { useQueryContributeUsers } from '@/services';
 import { Avatar } from '@/components';
+import { BASE_URL_PATH } from '@/router/alias';
 
 const Users = () => {
   const { t } = useTranslation('translation', { keyPrefix: 'users' });
@@ -69,7 +70,7 @@ const Users = () => {
                     xs={12}
                     className="mb-4">
                     <div className="d-flex">
-                      <Link to={`/users/${user.username}`}>
+                      <Link to={`${BASE_URL_PATH}/users/${user.username}`}>
                         <Avatar
                           size="48px"
                           avatar={user?.avatar}
@@ -80,7 +81,7 @@ const Users = () => {
                       <div className="ms-2">
                         <Link
                           className="text-break"
-                          to={`/users/${user.username}`}>
+                          to={`${BASE_URL_PATH}/users/${user.username}`}>
                           {user.display_name}
                         </Link>
                         <div className="text-secondary small">

--- a/ui/src/router/alias.ts
+++ b/ui/src/router/alias.ts
@@ -16,20 +16,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
+export const BASE_URL_PATH = process.env.REACT_APP_BASE_URL_PATH;
 export const RouteAlias = {
-  home: '/',
-  login: '/users/login',
-  signUp: '/users/register',
-  inactive: '/users/login?status=inactive',
-  accountRecovery: '/users/account-recovery',
-  changeEmail: '/users/change-email',
-  passwordReset: '/users/password-reset',
-  accountActivation: '/users/account-activation',
-  activationSuccess: '/users/account-activation/success',
-  activationFailed: '/users/account-activation/failed',
-  suspended: '/users/account-suspended',
-  confirmNewEmail: '/users/confirm-new-email',
-  confirmEmail: '/users/confirm-email',
-  authLanding: '/users/auth-landing',
+  home: `${BASE_URL_PATH}/`,
+  login: `${BASE_URL_PATH}/users/login`,
+  signUp: `${BASE_URL_PATH}/users/register`,
+  inactive: `${BASE_URL_PATH}/users/login?status=inactive`,
+  accountRecovery: `${BASE_URL_PATH}/users/account-recovery`,
+  changeEmail: `${BASE_URL_PATH}/users/change-email`,
+  passwordReset: `${BASE_URL_PATH}/users/password-reset`,
+  accountActivation: `${BASE_URL_PATH}/users/account-activation`,
+  activationSuccess: `${BASE_URL_PATH}/users/account-activation/success`,
+  activationFailed: `${BASE_URL_PATH}/users/account-activation/failed`,
+  suspended: `${BASE_URL_PATH}/users/account-suspended`,
+  confirmNewEmail: `${BASE_URL_PATH}/users/confirm-new-email`,
+  confirmEmail: `${BASE_URL_PATH}/users/confirm-email`,
+  authLanding: `${BASE_URL_PATH}/users/auth-landing`,
 };

--- a/ui/src/router/alias.ts
+++ b/ui/src/router/alias.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-export const BASE_URL_PATH = process.env.REACT_APP_BASE_URL_PATH;
+export const BASE_URL_PATH = process.env.REACT_APP_BASE_URL_PATH || '';
 export const RouteAlias = {
   home: `${BASE_URL_PATH}/`,
   login: `${BASE_URL_PATH}/users/login`,

--- a/ui/src/router/index.tsx
+++ b/ui/src/router/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import { Suspense, lazy } from 'react';
-import { RouteObject } from 'react-router-dom';
+import { Navigate, RouteObject } from 'react-router-dom';
 
 import Layout from '@/pages/Layout';
 
@@ -31,14 +31,20 @@ const routes: RouteNode[] = [];
 const routeWrapper = (routeNodes: RouteNode[], root: RouteNode[]) => {
   routeNodes.forEach((rn) => {
     if (rn.page === 'pages/Layout') {
-      rn.element = rn.guard ? (
-        <RouteGuard onEnter={rn.guard} path={rn.path} page={rn.page}>
+      if (rn.redirect) {
+        // Handle redirect
+        rn.element = <Navigate to={rn.redirect} replace />;
+        rn.errorElement = <RouteErrorBoundary />;
+      } else {
+        rn.element = rn.guard ? (
+          <RouteGuard onEnter={rn.guard} path={rn.path} page={rn.page}>
+            <Layout />
+          </RouteGuard>
+        ) : (
           <Layout />
-        </RouteGuard>
-      ) : (
-        <Layout />
-      );
-      rn.errorElement = <RouteErrorBoundary />;
+        );
+        rn.errorElement = <RouteErrorBoundary />;
+      }
     } else {
       /**
        * cannot use a fully dynamic import statement

--- a/ui/src/router/pathFactory.ts
+++ b/ui/src/router/pathFactory.ts
@@ -18,33 +18,40 @@
  */
 
 import { seoSettingStore } from '@/stores';
+import { BASE_URL_PATH } from '@/router/alias';
 
 const tagLanding = (slugName: string) => {
-  const r = slugName ? `/tags/${encodeURIComponent(slugName)}` : '/tags';
+  const r = slugName
+    ? `${BASE_URL_PATH}/tags/${encodeURIComponent(slugName)}`
+    : `${BASE_URL_PATH}/tags`;
   return r;
 };
 
 const tagInfo = (slugName: string) => {
-  const r = slugName ? `/tags/${encodeURIComponent(slugName)}/info` : '/tags';
+  const r = slugName
+    ? `${BASE_URL_PATH}/tags/${encodeURIComponent(slugName)}/info`
+    : `${BASE_URL_PATH}/tags`;
   return r;
 };
 
 const tagEdit = (tagId: string) => {
-  const r = `/tags/${tagId}/edit`;
+  const r = `${BASE_URL_PATH}/tags/${tagId}/edit`;
   return r;
 };
 
 const questionLanding = (questionId: string, slugTitle: string = '') => {
   const { seo } = seoSettingStore.getState();
   if (!questionId) {
-    return slugTitle ? `/questions/null/${slugTitle}` : '/questions/null';
+    return slugTitle
+      ? `${BASE_URL_PATH}/questions/null/${slugTitle}`
+      : `${BASE_URL_PATH}/questions/null`;
   }
   // @ts-ignore
   if (/[13]/.test(seo.permalink) && slugTitle) {
-    return `/questions/${questionId}/${slugTitle}`;
+    return `${BASE_URL_PATH}/questions/${questionId}/${slugTitle}`;
   }
 
-  return `/questions/${questionId}`;
+  return `${BASE_URL_PATH}/questions/${questionId}`;
 };
 
 const answerLanding = (params: {

--- a/ui/src/router/routes.ts
+++ b/ui/src/router/routes.ts
@@ -23,6 +23,7 @@ import { guard } from '@/utils';
 import type { TGuardFunc } from '@/utils/guard';
 import { editCheck } from '@/services';
 import { isEditable } from '@/utils/guard';
+import { BASE_URL_PATH } from '@/router/alias';
 
 type IndexRouteNode = Omit<IndexRouteObject, 'children'>;
 type NonIndexRouteNode = Omit<NonIndexRouteObject, 'children'>;
@@ -31,6 +32,7 @@ type UnionRouteNode = IndexRouteNode | NonIndexRouteNode;
 export type RouteNode = UnionRouteNode & {
   page: string;
   children?: RouteNode[];
+  redirect?: string;
   /**
    * a method to auto guard route before route enter
    * if the `ok` field in guard returned `TGuardResult` is true,
@@ -43,7 +45,7 @@ export type RouteNode = UnionRouteNode & {
 
 const routes: RouteNode[] = [
   {
-    path: '/',
+    path: `${BASE_URL_PATH}/`,
     page: 'pages/Layout',
     loader: async () => {
       await guard.setupApp();
@@ -108,7 +110,7 @@ const routes: RouteNode[] = [
             page: 'pages/Questions/Detail',
           },
           {
-            path: '/search',
+            path: `${BASE_URL_PATH}/search`,
             page: 'pages/Search',
             guard: () => {
               return guard.googleSnapshotRedirect();
@@ -192,21 +194,21 @@ const routes: RouteNode[] = [
             page: 'pages/Users/Notifications',
           },
           {
-            path: '/posts/:qid/timeline',
+            path: `${BASE_URL_PATH}/posts/:qid/timeline`,
             page: 'pages/Timeline',
             guard: () => {
               return guard.logged();
             },
           },
           {
-            path: '/posts/:qid/:aid/timeline',
+            path: `${BASE_URL_PATH}/posts/:qid/:aid/timeline`,
             page: 'pages/Timeline',
             guard: () => {
               return guard.logged();
             },
           },
           {
-            path: '/tags/:tid/timeline',
+            path: `${BASE_URL_PATH}/tags/:tid/timeline`,
             page: 'pages/Timeline',
             guard: () => {
               return guard.logged();
@@ -284,29 +286,29 @@ const routes: RouteNode[] = [
         },
       },
       {
-        path: '/users/account-activation/failed',
+        path: `${BASE_URL_PATH}/users/account-activation/failed`,
         page: 'pages/Users/ActivationResult',
         guard: () => {
           return guard.notActivated();
         },
       },
       {
-        path: '/users/confirm-new-email',
+        path: `${BASE_URL_PATH}/users/confirm-new-email`,
         page: 'pages/Users/ConfirmNewEmail',
       },
       {
-        path: '/users/account-suspended',
+        path: `${BASE_URL_PATH}/users/account-suspended`,
         page: 'pages/Users/Suspended',
         guard: () => {
           return guard.forbidden();
         },
       },
       {
-        path: '/users/confirm-email',
+        path: `${BASE_URL_PATH}/users/confirm-email`,
         page: 'pages/Users/OauthBindEmail',
       },
       {
-        path: '/users/auth-landing',
+        path: `${BASE_URL_PATH}/users/auth-landing`,
         page: 'pages/Users/AuthCallback',
       },
       // for admin
@@ -408,7 +410,7 @@ const routes: RouteNode[] = [
         ],
       },
       {
-        path: '/user-center/auth',
+        path: `${BASE_URL_PATH}/user-center/auth`,
         page: 'pages/UserCenter/Auth',
         guard: () => {
           const notLogged = guard.notLogged();
@@ -416,7 +418,7 @@ const routes: RouteNode[] = [
         },
       },
       {
-        path: '/user-center/auth-failed',
+        path: `${BASE_URL_PATH}/user-center/auth-failed`,
         page: 'pages/UserCenter/AuthFailed',
       },
       {
@@ -430,7 +432,7 @@ const routes: RouteNode[] = [
     ],
   },
   {
-    path: '/',
+    path: `${BASE_URL_PATH}/`,
     page: 'pages/Layout',
     loader: async () => {
       await guard.setupApp();
@@ -456,7 +458,7 @@ const routes: RouteNode[] = [
         ],
       },
       {
-        path: '/users/unsubscribe',
+        path: `${BASE_URL_PATH}/users/unsubscribe`,
         page: 'pages/Users/Unsubscribe',
       },
       {
@@ -466,12 +468,18 @@ const routes: RouteNode[] = [
     ],
   },
   {
-    path: '/install',
+    path: `${BASE_URL_PATH}/install`,
     page: 'pages/Install',
   },
   {
-    path: '/maintenance',
+    path: `${BASE_URL_PATH}/maintenance`,
     page: 'pages/Maintenance',
+  },
+  // Default route for all other paths
+  {
+    path: '/:path(.*)', // Match any path
+    page: 'pages/Layout',
+    redirect: `${BASE_URL_PATH}/`, // Redirect to BASE_URL_PATH
   },
 ];
 export default routes;


### PR DESCRIPTION
# Problem
I would love to use the second-level domain name of nginx to deploy `Answer`. However, this requires the  webapp to work on relative url path (e.g. /foo/questions) or support setting a base url via configuration.

# Solution
Add support for setting a base/root url in the configuration or make the webapp work on relativ urls. Having this option is very useful in a variety of deployment scenarios (e.g. behind a reverse proxy).

Adds the config option `REACT_APP_BASE_URL_PATH` . When set to a value like `/foo`, Anwser will be served from `hostname:port/foo`.

# Usage

1. edit the `ui/.env.production` file
```text
...
REACT_APP_BASE_URL_PATH=/foo
...
```
2. Recompile
```shell
make ui
make build
```

3. Initialization and Run
```shell
# Initialization
INSTALL_PORT=9080 REACT_APP_BASE_URL_PATH=/foo ./answer init -C ./answer-data/
# Run
REACT_APP_BASE_URL_PATH=/foo ./answer run -C ./answer-data/
```

>Note：
>
>1. If the value of `REACT_APP_BASE_URL_PATH` is the default `""`, there is no need to set the environment variable.
>2. The value of `REACT_APP_BASE_URL_PATH` must not end with `/`. For example, `PUBLIC_URL=/foo` is correct, while `PUBLIC_URL=/foo/` is incorrect.

