### PR TITLE
fix: not changing rank for newly registered user when changing mail

### DIFF
--- a/internal/service/user_service.go
+++ b/internal/service/user_service.go
@@ -23,9 +23,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
+
 	"github.com/apache/incubator-answer/internal/base/constant"
 	"github.com/apache/incubator-answer/internal/service/user_notification_config"
-	"time"
 
 	"github.com/apache/incubator-answer/internal/base/handler"
 	"github.com/apache/incubator-answer/internal/base/reason"
@@ -643,6 +644,12 @@ func (us *UserService) UserChangeEmailVerify(ctx context.Context, content string
 	err = us.userRepo.UpdateEmailStatus(ctx, data.UserID, entity.EmailStatusAvailable)
 	if err != nil {
 		return nil, err
+	}
+	// if email status is to be verified, active user as well
+	if userInfo.MailStatus == entity.EmailStatusToBeVerified {
+		if err = us.userActivity.UserActive(ctx, userInfo.ID); err != nil {
+			log.Error(err)
+		}
 	}
 
 	roleID, err := us.userRoleService.GetUserRole(ctx, userInfo.ID)


### PR DESCRIPTION
fix #832 .

I think the root cause is that for newly registered user whose mail status is 'to be verified', when they change their mail, the `PUT /answer/api/v1/user/email` API will only update the mail status without adding rank. 

Hi @LinkinStars , pls help to review and let me know if I missed anything. Thanks!