### PR TITLE
fix: sometimes the comment link in the notification cannot be highlighted after clicking

### DIFF
--- a/ui/src/components/Comment/index.tsx
+++ b/ui/src/components/Comment/index.tsx
@@ -73,7 +73,7 @@ const Comment = ({ objectId, mode, commentId }) => {
   const { t } = useTranslation('translation', { keyPrefix: 'comment' });
 
   useEffect(() => {
-    if (pageIndex === 0 && commentId) {
+    if (pageIndex === 0 && commentId && comments.length !== 0) {
       setTimeout(() => {
         const el = document.getElementById(commentId);
         scrollToElementTop(el);
@@ -84,7 +84,7 @@ const Comment = ({ objectId, mode, commentId }) => {
     return () => {
       updateCurrentReplyId('');
     };
-  }, []);
+  }, [comments]);
 
   useEffect(() => {
     if (!data) {


### PR DESCRIPTION
fix #900 , the root cause should be that sometimes, the comments data have not been received by client and there's no corresponding element.