### PR TITLE
feat: allow tables to be scrolled horizontally with ease in Admin

### DIFF
--- a/ui/src/pages/Admin/Questions/index.tsx
+++ b/ui/src/pages/Admin/Questions/index.tsx
@@ -91,10 +91,10 @@ const Questions: FC = () => {
           style={{ width: '12.25rem' }}
         />
       </div>
-      <Table>
+      <Table responsive>
         <thead>
           <tr>
-            <th>{t('post')}</th>
+            <th className="post-column">{t('post')}</th>
             <th style={{ width: '8%' }}>{t('votes')}</th>
             <th style={{ width: '8%' }}>{t('answers')}</th>
             <th style={{ width: '15%' }}>{t('created')}</th>

--- a/ui/src/pages/Admin/index.scss
+++ b/ui/src/pages/Admin/index.scss
@@ -21,3 +21,9 @@
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
 }
+
+.table {
+  .post-column {
+    min-width: 15rem;
+  }
+}


### PR DESCRIPTION
fix #917 , I just blindly set the `min-width` of post column to `15rem`, pls let me know if any comment. ++@shuashuai to help to review. Thanks!

![image](https://github.com/apache/incubator-answer/assets/11908658/766f1d8c-c3ee-493b-a0cd-f622f54bdd89)
