### PR TITLE
fix: Chinese character tag bug

### DIFF
--- a/ui/src/components/Tag/index.tsx
+++ b/ui/src/components/Tag/index.tsx
@@ -38,7 +38,7 @@ const Index: FC<IProps> = ({
   className = '',
   textClassName = '',
 }) => {
-  href ||= pathFactory.tagLanding(encodeURIComponent(data.slug_name));
+  href ||= pathFactory.tagLanding(data.slug_name);
 
   return (
     <Link


### PR DESCRIPTION
#961 

The reason for the error handling of escaped characters in the `tag component` is due to the redundant use of the encodeURIComponent function when passing the slug parameter. The `slugName` has already been processed in `pathFactory.tagLanding`, so it does not need to be processed again when passing parameters.

I'm sorry for the incorrect operations on my Git.

Thanks for your help @LinkinStars @shuashuai 
