### PR TITLE
support to display the relevant database info when switching databases

### DIFF
--- a/licenserc.toml
+++ b/licenserc.toml
@@ -34,7 +34,3 @@ excludes = [
   "charts/templates/_helpers.tpl",
   "charts/.helmignore",
 ]
-
-[properties]
-inceptionYear = 2024
-copyrightOwner = "tison <wander4096@gmail.com>"

--- a/ui/src/pages/Install/index.tsx
+++ b/ui/src/pages/Install/index.tsx
@@ -131,11 +131,35 @@ const Index: FC = () => {
     },
   });
 
+  const updateFormData = (params: FormDataType) => {
+    if (step === 2) {
+      let updatedFormData = formData;
+      if (params.db_type.value === 'mysql') {
+        updatedFormData = {
+          ...updatedFormData,
+          db_username: { ...updatedFormData.db_username, value: 'root' },
+          db_password: { ...updatedFormData.db_password, value: 'root' },
+          db_host: { ...updatedFormData.db_host, value: 'db:3306' },
+        };
+      } else if (params.db_type.value === 'postgres') {
+        updatedFormData = {
+          ...updatedFormData,
+          db_username: { ...updatedFormData.db_username, value: 'postgres' },
+          db_password: { ...updatedFormData.db_password, value: 'postgres' },
+          db_host: { ...updatedFormData.db_host, value: 'db:5432' },
+        };
+      }
+      return updatedFormData;
+    }
+    return formData;
+  };
+  
   const handleChange = (params: FormDataType) => {
     setErrorData({
       msg: '',
     });
-    setFormData({ ...formData, ...params });
+    const updatedFormData = updateFormData(params);
+    setFormData({ ...updatedFormData, ...params });
   };
 
   const handleErr = (data) => {

--- a/ui/src/pages/Install/index.tsx
+++ b/ui/src/pages/Install/index.tsx
@@ -132,7 +132,7 @@ const Index: FC = () => {
   });
 
   const updateFormData = (params: FormDataType) => {
-    if (step === 2) {
+    if (Object.keys(params)?.[0] === 'db_type') {
       let updatedFormData = formData;
       if (params.db_type.value === 'mysql') {
         updatedFormData = {


### PR DESCRIPTION
Support switching databases to display the relevant database configurations during the initial installation

When switching to Mysql, use:
Username: root
Password: root
Database host: db:3306
<img width="554" alt="image" src="https://github.com/user-attachments/assets/41a1cb4b-d141-4fea-93d6-08be789e55ad">


When switching to Postgres, use
Username: postgres
Password: postgres
Database host: db:5432
<img width="553" alt="image" src="https://github.com/user-attachments/assets/c053f810-c849-47b8-a15f-311ad79e0fb5">
