### PR TITLE
feat(helm): add persistence.dataSource to helm chart

### DIFF
--- a/charts/templates/pvc.yaml
+++ b/charts/templates/pvc.yaml
@@ -20,7 +20,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ include "answer.fullname" . }}-claim
-  {{- with .Values.persistence.annotations  }}
+  {{- with .Values.persistence.annotations }}
   annotations:
     {{ toYaml . | indent 4 }}
   {{- end }}
@@ -39,4 +39,10 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
+  {{- with .Values.persistence.dataSource }}
+  dataSource:
+    name: {{ .name }}
+    kind: {{ .kind | default "VolumeSnapshot" }}
+    apiGroup: {{ .apiGroup | default "snapshot.storage.k8s.io" }}
+  {{- end }}
 {{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -68,7 +68,7 @@ env:
 
 # Configure extra containers
 extraContainers: []
-  # - name: cloudsql-proxy 
+  # - name: cloudsql-proxy
   #   image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.1.2
   #   command:
   #     - /cloud-sql-proxy
@@ -91,6 +91,12 @@ persistence:
   accessMode: ReadWriteOnce
   size: 5Gi
   annotations: {}
+  # To restore a PVC from a VolumeSnapshot, set the dataSource;
+  # the kind and apiGroup are optional and default to the shown values
+  dataSource: {}
+    # name: my-volume-snapshot
+    # kind: VolumeSnapshot
+    # apiGroup: snapshot.storage.k8s.io
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
This allows restoring the application with a backup of the data. Tested this with a VolumeSnapshot on an AWS EKS cluster.

```yaml
---
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshotClass
metadata:
  name: test-snapclass
driver: ebs.csi.aws.com
deletionPolicy: Delete
---
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshot
metadata:
  name: test-snapshot
spec:
  volumeSnapshotClassName: test-snapclass
  source:
    persistentVolumeClaimName: answer-claim
```

Reference: https://kubernetes.io/docs/concepts/storage/volume-snapshots/