### PR TITLE
fix Error 1055 in ListNewestEarned

### DIFF
--- a/internal/repo/badge_award/badge_award_repo.go
+++ b/internal/repo/badge_award/badge_award_repo.go
@@ -139,7 +139,7 @@ func (r *badgeAwardRepo) ListPagedByBadgeIdAndUserId(ctx context.Context, badgeI
 func (r *badgeAwardRepo) ListNewestEarned(ctx context.Context, userID string, limit int) (badgeAwards []*entity.BadgeAwardRecent, err error) {
 	badgeAwards = make([]*entity.BadgeAwardRecent, 0)
 	err = r.data.DB.Context(ctx).
-		Select("user_id, badge_id, max(created_at) created,count(*) earned_count").
+		Select("any_value(user_id), badge_id, max(created_at) created,count(*) earned_count").
 		Where("user_id = ? AND is_badge_deleted = ? ", userID, entity.IsBadgeNotDeleted).
 		GroupBy("badge_id").
 		OrderBy("created desc").


### PR DESCRIPTION
In higher versions of MySQL, when executing group by, if the select field does not belong to the group by field, the SQL statement will report error 1055. 
See #1093 