### PR TITLE
fix: display error message and HTML for invalid order

### DIFF
--- a/internal/controller/template_controller.go
+++ b/internal/controller/template_controller.go
@@ -139,7 +139,6 @@ func (tc *TemplateController) Index(ctx *gin.Context) {
 		OrderCond: "newest",
 	}
 	if handler.BindAndCheck(ctx, req) {
-		tc.Page404(ctx)
 		return
 	}
 
@@ -182,7 +181,6 @@ func (tc *TemplateController) QuestionList(ctx *gin.Context) {
 		OrderCond: "newest",
 	}
 	if handler.BindAndCheck(ctx, req) {
-		tc.Page404(ctx)
 		return
 	}
 	var page = req.Page

--- a/internal/schema/question_schema.go
+++ b/internal/schema/question_schema.go
@@ -346,6 +346,7 @@ const (
 	QuestionOrderCondHot        = "hot"
 	QuestionOrderCondScore      = "score"
 	QuestionOrderCondUnanswered = "unanswered"
+	QuestionOrderCondRecommend  = "recommend"
 
 	// HotInDays limit max days of the hottest question
 	HotInDays = 90


### PR DESCRIPTION
https://meta.answer.dev/questions?order=xxx

<img width="1096" alt="image" src="https://github.com/user-attachments/assets/bbfad35c-1335-4b1b-bf5c-2a6059ce01aa">


