### PR TITLE
Fix tag relationship processing errors

### DIFF
--- a/internal/repo/repo_test/tag_rel_repo_test.go
+++ b/internal/repo/repo_test/tag_rel_repo_test.go
@@ -104,7 +104,7 @@ func Test_tagListRepo_GetObjectTagRelWithoutStatus(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, exist)
 
-	err = tagRelRepo.EnableTagRelByIDs(context.TODO(), ids)
+	err = tagRelRepo.EnableTagRelByIDs(context.TODO(), ids, false)
 	assert.NoError(t, err)
 
 	count, err = tagRelRepo.CountTagRelByTagID(context.TODO(), "10030000000000101")

--- a/internal/repo/tag/tag_rel_repo.go
+++ b/internal/repo/tag/tag_rel_repo.go
@@ -130,8 +130,12 @@ func (tr *tagRelRepo) GetObjectTagRelWithoutStatus(ctx context.Context, objectID
 }
 
 // EnableTagRelByIDs update tag status to available
-func (tr *tagRelRepo) EnableTagRelByIDs(ctx context.Context, ids []int64) (err error) {
-	_, err = tr.data.DB.Context(ctx).In("id", ids).Update(&entity.TagRel{Status: entity.TagRelStatusAvailable})
+func (tr *tagRelRepo) EnableTagRelByIDs(ctx context.Context, ids []int64, hide bool) (err error) {
+	status := entity.TagRelStatusAvailable
+	if hide {
+		status = entity.TagRelStatusHide
+	}
+	_, err = tr.data.DB.Context(ctx).In("id", ids).Update(&entity.TagRel{Status: status})
 	if err != nil {
 		err = errors.InternalServer(reason.DatabaseError).WithError(err).WithStack()
 	}
@@ -185,4 +189,17 @@ func (tr *tagRelRepo) CountTagRelByTagID(ctx context.Context, tagID string) (cou
 		err = errors.InternalServer(reason.DatabaseError).WithError(err).WithStack()
 	}
 	return
+}
+
+// GetTagRelDefaultStatusByObjectID get tag rel default status
+func (tr *tagRelRepo) GetTagRelDefaultStatusByObjectID(ctx context.Context, objectID string) (status int, err error) {
+	question := entity.Question{}
+	exist, err := tr.data.DB.Context(ctx).ID(objectID).Cols("show", "status").Get(&question)
+	if err != nil {
+		err = errors.InternalServer(reason.DatabaseError).WithError(err).WithStack()
+	}
+	if exist && (question.Show == entity.QuestionHide || question.Status == entity.QuestionStatusDeleted) {
+		return entity.TagRelStatusHide, nil
+	}
+	return entity.TagRelStatusAvailable, nil
 }

--- a/internal/repo/tag/tag_rel_repo.go
+++ b/internal/repo/tag/tag_rel_repo.go
@@ -21,6 +21,7 @@ package tag
 
 import (
 	"context"
+
 	"github.com/apache/incubator-answer/internal/base/data"
 	"github.com/apache/incubator-answer/internal/base/handler"
 	"github.com/apache/incubator-answer/internal/base/reason"
@@ -85,7 +86,7 @@ func (tr *tagRelRepo) RecoverTagRelListByObjectID(ctx context.Context, objectID 
 
 func (tr *tagRelRepo) HideTagRelListByObjectID(ctx context.Context, objectID string) (err error) {
 	objectID = uid.DeShortID(objectID)
-	_, err = tr.data.DB.Context(ctx).Where("object_id = ?", objectID).Cols("status").Update(&entity.TagRel{Status: entity.TagRelStatusHide})
+	_, err = tr.data.DB.Context(ctx).Where("object_id = ?", objectID).And("status = ?", entity.TagRelStatusAvailable).Cols("status").Update(&entity.TagRel{Status: entity.TagRelStatusHide})
 	if err != nil {
 		err = errors.InternalServer(reason.DatabaseError).WithError(err).WithStack()
 	}
@@ -94,7 +95,7 @@ func (tr *tagRelRepo) HideTagRelListByObjectID(ctx context.Context, objectID str
 
 func (tr *tagRelRepo) ShowTagRelListByObjectID(ctx context.Context, objectID string) (err error) {
 	objectID = uid.DeShortID(objectID)
-	_, err = tr.data.DB.Context(ctx).Where("object_id = ?", objectID).Cols("status").Update(&entity.TagRel{Status: entity.TagRelStatusAvailable})
+	_, err = tr.data.DB.Context(ctx).Where("object_id = ?", objectID).And("status = ?", entity.TagRelStatusHide).Cols("status").Update(&entity.TagRel{Status: entity.TagRelStatusAvailable})
 	if err != nil {
 		err = errors.InternalServer(reason.DatabaseError).WithError(err).WithStack()
 	}

--- a/internal/service/tag_common/tag_common.go
+++ b/internal/service/tag_common/tag_common.go
@@ -290,24 +290,18 @@ func (ts *TagCommonService) ExistRecommend(ctx context.Context, tags []*schema.T
 
 func (ts *TagCommonService) HasNewTag(ctx context.Context, tags []*schema.TagItem) (bool, error) {
 	tagNames := make([]string, 0)
-	tagMap := make(map[string]bool)
+	tagMap := make(map[string]struct{})
 	for _, item := range tags {
 		item.SlugName = strings.ReplaceAll(item.SlugName, " ", "-")
 		tagNames = append(tagNames, item.SlugName)
-		tagMap[item.SlugName] = false
+		tagMap[item.SlugName] = struct{}{}
 	}
 	list, err := ts.GetTagListByNames(ctx, tagNames)
 	if err != nil {
 		return true, err
 	}
 	for _, item := range list {
-		_, ok := tagMap[item.SlugName]
-		if ok {
-			tagMap[item.SlugName] = true
-		}
-	}
-	for _, has := range tagMap {
-		if !has {
+		if _, ok := tagMap[item.SlugName]; !ok {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
## Description

This PR addresses three issues:

1. Optimizes the performance of checking for new tags.
2. Fixes an issue where tag relationships had incorrect status when enabled.
3. Adds status filtering when updating tag relationships.

These changes are related to the bug reported in #1144

## Changes

1. Optimized `HasNewTag` function in `internal/service/tag_common/tag_common.go`:
   - Replaced `map[string]bool` with `map[string]struct{}` for better memory efficiency.
   - Simplified the logic to check for new tags, reducing unnecessary iterations.

2. Fixed tag relationship status when enabling:
   - Added logic to consider the question's status (hidden/visible) when restoring tag relationships.

3. Added status filtering when updating tag relationships:
   - Implemented filtering to exclude deleted data when restoring hidden tag relationships.

## Testing

Please test the following scenarios:

1. Unlisting a question with multiple tags
2. Editing an unlisted question (removing and adding tags)
3. Listing the question again

Verify that:
- Removed tags are not displayed after listing the question
- Tag relationships are correctly maintained when changing list/unlist status
- Performance is improved for operations involving tag checks

## Additional Notes

This PR aims to resolve the issues mentioned in #1144 and improve overall tag handling in the system. Please review and provide feedback if any further changes are needed.